### PR TITLE
add validates() method to webAccessControl

### DIFF
--- a/__tests__/__fixtures__/noAccessToPredicate.ttl
+++ b/__tests__/__fixtures__/noAccessToPredicate.ttl
@@ -1,0 +1,7 @@
+@prefix acl:  <http://www.w3.org/ns/auth/acl#> .
+
+<http://platform:8080/#auth>
+        acl:agentClass  <http://xmlns.com/foaf/0.1/Agent> ;
+        acl:mode        acl:Control ;
+        acl:mode        acl:Write ;
+        acl:mode        acl:Read .

--- a/__tests__/__fixtures__/noAclReadIncluded.ttl
+++ b/__tests__/__fixtures__/noAclReadIncluded.ttl
@@ -1,0 +1,7 @@
+@prefix acl:  <http://www.w3.org/ns/auth/acl#> .
+
+<http://platform:8080/#auth>
+        acl:accessTo    <http://platform:8080/> ;
+        acl:agentClass  <http://xmlns.com/foaf/0.1/Agent> ;
+        acl:mode        acl:Control ;
+        acl:mode        acl:Write .

--- a/__tests__/__fixtures__/noAgentClassPredicate.ttl
+++ b/__tests__/__fixtures__/noAgentClassPredicate.ttl
@@ -1,0 +1,7 @@
+@prefix acl:  <http://www.w3.org/ns/auth/acl#> .
+
+<http://platform:8080/#auth>
+        acl:accessTo    <http://platform:8080/> ;
+        acl:mode        acl:Control ;
+        acl:mode        acl:Write ;
+        acl:mode        acl:Read .

--- a/__tests__/__fixtures__/noGroupUsers.ttl
+++ b/__tests__/__fixtures__/noGroupUsers.ttl
@@ -1,0 +1,12 @@
+@prefix acl:  <http://www.w3.org/ns/auth/acl#> .
+
+<http://platform:8080/#stanford-edit>
+        acl:mode      acl:Read ;
+        acl:mode      acl:Write ;
+        acl:mode      acl:Control ;
+        acl:accessTo  <http://platform:8080/stanford> .
+
+<http://platform:8080/#stanford-read>
+        acl:mode        acl:Read ;
+        acl:agentClass  <http://xmlns.com/foaf/0.1/Agent> ;
+        acl:accessTo    <http://platform:8080/stanford> .

--- a/__tests__/webAccessControl.test.js
+++ b/__tests__/webAccessControl.test.js
@@ -79,4 +79,40 @@ describe('WebAccessControl', () => {
     })
   })
 
+  describe('validates()', () => {
+    it('throws error when there is no acl:accessTo predicate', () => {
+      const wac = new WebAccessControl(fs.readFileSync(`${fixture_dir}/noAccessToPredicate.ttl`).toString())
+      expect(() => {
+        wac.validates()
+      }).toThrow('invalid WAC: no http://www.w3.org/ns/auth/acl#accessTo predicate')
+    })
+    it('throws error when there is no acl:agentClass predicate', () => {
+      const wac = new WebAccessControl(fs.readFileSync(`${fixture_dir}/noAgentClassPredicate.ttl`).toString())
+      expect(() => {
+        wac.validates()
+      }).toThrow('invalid WAC: no http://www.w3.org/ns/auth/acl#agentClass predicate')
+    })
+    it('throws error when there is no acl:mode acl:Read predicate-object pair', () => {
+      const wac = new WebAccessControl(fs.readFileSync(`${fixture_dir}/noAclReadIncluded.ttl`).toString())
+      expect(() => {
+        wac.validates()
+      }).toThrow('invalid WAC: no http://www.w3.org/ns/auth/acl#Read permissions')
+    })
+    it('throws error when a group has no acl:agent predicate', () => {
+      const wac = new WebAccessControl(fs.readFileSync(`${fixture_dir}/noGroupUsers.ttl`).toString())
+      expect(() => {
+        wac.validates()
+      }).toThrow('invalid WAC: group container requires http://www.w3.org/ns/auth/acl#agent webids')
+    })
+    it('returns true when this.n3store root container contents pass validates', () => {
+      const wac = new WebAccessControl(fs.readFileSync(`${fixture_dir}/defaultBaseAcl.ttl`).toString())
+      expect(wac.validates()).toBeTruthy()
+      wac.parseWac(fs.readFileSync(`${fixture_dir}/cmharlowBaseAcl.ttl`).toString())
+      expect(wac.validates()).toBeTruthy()
+    })
+    it('returns true when this.n3store group container contents pass validates', () => {
+      const wac = new WebAccessControl(fs.readFileSync(`${fixture_dir}/stanfordGroupAcl_2Users.ttl`).toString())
+      expect(wac.validates()).toBeTruthy()
+    })
+  })
 })

--- a/__tests__/webAccessControl.test.js
+++ b/__tests__/webAccessControl.test.js
@@ -25,62 +25,58 @@ describe('WebAccessControl', () => {
     expect(myWac.hasUser('http://example.com/nobody')).toBeFalsy()
   })
 
-  describe('ttl fixture', () => {
-    beforeAll(() => {
-      myWac.parseWac(fs.readFileSync(`${fixture_dir}/cmharlowBaseAcl.ttl`).toString())
-    })
+  describe('hasUser()', () => {
+    describe('ttl fixture', () => {
+      beforeAll(() => {
+        myWac.parseWac(fs.readFileSync(`${fixture_dir}/cmharlowBaseAcl.ttl`).toString())
+      })
 
-    describe('hasUser()', () => {
       it('true when user has access', () => {
         expect(myWac.hasUser('http://sinopia.io/users/cmharlow')).toBeTruthy()
       })
       it('false when user does not have access', () => {
         expect(myWac.hasUser('http://example.com/nobody')).toBeFalsy()
       })
-
-      it('false when the wac has no users (does not error)', () => {
-        const wac = new WebAccessControl()
-        wac.parseWac(fs.readFileSync(`${fixture_dir}/defaultBaseAcl.ttl`).toString())
-        expect(wac.hasUser('http://example.com/nobody')).toBeFalsy()
-      })
-      it('false when the wac is an empty string', () => {
-        const wac = new WebAccessControl()
-        wac.parseWac('')
-        expect(wac.hasUser('http://example.com/nobody')).toBeFalsy()
-      })
-      it('false when no wac is parsed', () => {
-        const wac = new WebAccessControl()
-        expect(wac.hasUser('http://example.com/nobody')).toBeFalsy()
-      })
     })
 
-    describe('listUsers()', () => {
-      it('lists the webids of the users', () => {
-        myWac.parseWac(fs.readFileSync(`${fixture_dir}/cmharlowBaseAcl.ttl`).toString())
-        expect(myWac.listUsers()).toEqual(['http://sinopia.io/users/cmharlow'])
+    it('false when the wac has no users (does not error)', () => {
+      myWac.parseWac(fs.readFileSync(`${fixture_dir}/defaultBaseAcl.ttl`).toString())
+      expect(myWac.hasUser('http://example.com/nobody')).toBeFalsy()
+    })
+    it('false when the wac is an empty string', () => {
+      myWac.parseWac('')
+      expect(myWac.hasUser('http://example.com/nobody')).toBeFalsy()
+    })
+    it('false when no wac is parsed', () => {
+      const wac = new WebAccessControl()
+      expect(wac.hasUser('http://example.com/nobody')).toBeFalsy()
+    })
+  })
 
-        myWac.parseWac(fs.readFileSync(`${fixture_dir}/stanfordGroupAcl_2Users.ttl`).toString())
-        expect(myWac.listUsers()).toContain('http://sinopia.io/users/cmharlow')
-        expect(myWac.listUsers()).toContain('http://sinopia.io/users/suntzu')
-      })
+  describe('listUsers()', () => {
+    it('lists the webids of the users', () => {
+      myWac.parseWac(fs.readFileSync(`${fixture_dir}/cmharlowBaseAcl.ttl`).toString())
+      expect(myWac.listUsers()).toEqual(['http://sinopia.io/users/cmharlow'])
 
-      it('empty array when the wac has no users (does not error)', () => {
-        const wac = new WebAccessControl()
-        wac.parseWac(fs.readFileSync(`${fixture_dir}/defaultBaseAcl.ttl`).toString())
-        expect(wac.listUsers()).toEqual([])
-      })
-      it('empty array when the wac is an empty string', () => {
-        const wac = new WebAccessControl()
-        wac.parseWac('')
-        expect(wac.listUsers()).toEqual([])
-      })
-      it('empty array when no wac is parsed', () => {
-        const wac = new WebAccessControl()
-        expect(wac.listUsers()).toEqual([])
-      })
+      myWac.parseWac(fs.readFileSync(`${fixture_dir}/stanfordGroupAcl_2Users.ttl`).toString())
+      expect(myWac.listUsers()).toContain('http://sinopia.io/users/cmharlow')
+      expect(myWac.listUsers()).toContain('http://sinopia.io/users/suntzu')
     })
 
-
+    it('empty array when the wac has no users (does not error)', () => {
+      const wac = new WebAccessControl()
+      wac.parseWac(fs.readFileSync(`${fixture_dir}/defaultBaseAcl.ttl`).toString())
+      expect(wac.listUsers()).toEqual([])
+    })
+    it('empty array when the wac is an empty string', () => {
+      const wac = new WebAccessControl()
+      wac.parseWac('')
+      expect(wac.listUsers()).toEqual([])
+    })
+    it('empty array when no wac is parsed', () => {
+      const wac = new WebAccessControl()
+      expect(wac.listUsers()).toEqual([])
+    })
   })
 
 })


### PR DESCRIPTION
We don't want to write WAC docs to the server that have egregious errors, so this is a little bit of validation to help avoid that.

Also reorged the existing tests to make test code more skimmable, as well as acknowledging that we will be dealing with ttl, not jsonld, for a while.

Connects to #3