### PR TITLE
update validates() indirectly via isMyGroupContainer(); partial impl of writing temp ttl file

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,16 @@ module.exports = {
         //   we get: "Import and export declarations are not supported yet"
         "node/no-unsupported-features/es-syntax": "off",
         // Avoiding: "warning  Found fs.readFileSync with non literal argument ..."
-        "security/detect-non-literal-fs-filename": "off"
+        "security/detect-non-literal-fs-filename": "off",
+        // Avoiding: "warning Found non-literal argument to RegExp Constructor"
+        "security/detect-non-literal-regexp": "off"
+      }
+    },
+    {
+      "files": ["src/webAccessControl.js"],
+      "rules": {
+        // we currently DO want to send errors to console
+        "no-console": "off"
       }
     },
     {

--- a/config/default.js
+++ b/config/default.js
@@ -1,0 +1,7 @@
+module.exports = {
+  adminUsers: // webid list for users that will get acl:Control permissions for all groups
+    [
+      'webid4Admin1',
+      'webid4Admin2'
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1687,6 +1687,24 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "config": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/config/-/config-3.0.1.tgz",
+      "integrity": "sha512-TBNrrk2b6AybUohqXw2AydglFBL9b/+1GG93Di6Fm6x1SyVJ5PYgo+mqY2X0KpU9m0PJDSbFaC5H95utSphtLw==",
+      "requires": {
+        "json5": "^1.0.1"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        }
+      }
+    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -4018,8 +4036,7 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@babel/runtime": "^7.3.4",
     "commander": "^2.19.0",
+    "config": "^3.0.1",
     "n3": "^1.0.4"
   }
 }


### PR DESCRIPTION
Connects to #3 
Closes #24

This is an interim PR on the way to being able to write webACL to a specific Sinopia group container.  Two questions are inserted below.  

- tightens group container validation -- the group passed into the constructor must match the group referenced with acl:accessTo
- introduces config package for configuration variables.  ~~Used here for tempDir for ttl files, but~~ have placeholders for admin webids ~~and initialGroupWebAcl - the baseline RDF needed for webACL for a new group.~~
- calls console.error for validation errors on webACL, with eslint exception to allow it.  (QUESTION:  does writing errors to console make sense?  is there a better way?)

~~We may choose NOT to write the webACL RDF to a file before sending it to Sinopia server;  I somehow convinced myself it was necessary to have the webACL as a file and have started down this path.~~

~~My preference is to add the tests ensuring the ttl created from N3Store is exactly what we want to send to Sinopia server _before_ altering course re: writing temp ttl file.~~

~~(QUESTION: should we write temp files of ttl?  If not, is it ok to rip it out with a later PR, or would you like it removed immediately?) - REMOVED IT.~~