### PR TITLE
Add initial integration test for WebAccessControl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,20 +34,26 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - setup_remote_docker
       - restore_cache:
           key: dependency-cache-ci-{{ checksum "package.json" }}
-      - run: npm run eslint
+      - run:
+          name: Run linter (eslint)
+          command: npm run eslint
       - run:
           name: Setup Code Climate test-reporter
           command: |
             curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
             chmod +x ./cc-test-reporter
       - run:
-          name: test with jest
+          name: Run jest unit tests
           command: |
             ./cc-test-reporter before-build
             npm run jest-ci
             ./cc-test-reporter after-build --exit-code $?
+      - run:
+          name: Run integration tests
+          command: docker-compose run integration
 
 workflows:
   version: 2

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,6 +42,24 @@ module.exports = {
         'no-console': 'off',
         'no-process-exit': 'off'
       }
+    },
+    {
+      // Allow explicit boolean casts in integration tests to permit running inside and outside containerland
+      files: [
+        '__tests__/**/*.integration.js'
+      ],
+      rules: {
+        'no-extra-boolean-cast': 'off',
+      }
+    },
+    {
+      // Allow skipped tests in test suite
+      files: [
+        '__tests__/**/*.js'
+      ],
+      rules: {
+        'jest/no-disabled-tests': 'off',
+      }
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -12,15 +12,37 @@ The "copy of record" of group/webID mappings will be in the Sinopia server.
 
 ## Testing
 
-Using `docker-compose`, you can spin up a container with Trellis(, Postgres, ActiveMQ and this repo's code):
+To run the linter and unit tests:
 
 ```shell
-$ docker-compose up
+$ npm run eslint
+$ npm test
 ```
 
-To shut it down and clean up, run:
+### Integration
+
+First spin up the integration environment (Trellis, its dependencies, and this repo's code) using `docker-compose`:
 
 ```shell
+$ docker-compose up -d platform
+```
+
+To run the integration tests, they must be invoked independent of the unit tests:
+
+```shell
+$ npm run jest-integration
+```
+
+To shut the containers down and clean up, run:
+
+```shell
+$ docker-compose down
+```
+
+Or to bundle the above commands (mimicking how integration tests are run in CI), you can invoke the integration tests via:
+
+```shell
+$ docker-compose run integration
 $ docker-compose down
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ npm test
 
 ### Integration
 
-First spin up the integration environment (Trellis, its dependencies, and this repo's code) using `docker-compose`:
+If you're going to be doing active development, you'll most likely want to spin up `docker-compose` services and run integration tests separately, since you will do this multiple times while getting the code right. If so, first spin up the integration environment—Trellis & its dependencies—in the background (via `-d`) using `docker-compose`:
 
 ```shell
 $ docker-compose up -d platform
@@ -39,7 +39,7 @@ To shut the containers down and clean up, run:
 $ docker-compose down
 ```
 
-Or to bundle the above commands (mimicking how integration tests are run in CI), you can invoke the integration tests via:
+Or if you just need to run the integration tests once (assuming you haven't already started up `docker-compose` services), you can do the following to spin up containers, run integration tests, and then spin containers down. (This is how integration tests are run in CI.)
 
 ```shell
 $ docker-compose run integration

--- a/__tests__/webAccessControl.integration.js
+++ b/__tests__/webAccessControl.integration.js
@@ -1,0 +1,24 @@
+import superagent from 'superagent'
+import N3 from 'n3'
+import { WebAccessControl } from '../src/webAccessControl'
+
+const { DataFactory } = N3
+const { namedNode } = DataFactory
+const rootAclUrl = Boolean(process.env.INSIDE_CONTAINER) ? 'http://platform:8080/?ext=acl' : 'http://localhost:8080/?ext=acl'
+
+describe('WebAccessControl integration', () => {
+  test('base container ACLs can be parsed', async  () => {
+    const rootAcls = await superagent.get(rootAclUrl).accept('text/turtle')
+    const rootNode = namedNode('http://platform:8080/#auth')
+    const webAC = new WebAccessControl(rootAcls.text)
+    expect(
+      webAC.n3store.countQuads(rootNode, namedNode('http://www.w3.org/ns/auth/acl#accessTo'), namedNode('http://platform:8080/'))
+    ).toBe(1)
+    expect(
+      webAC.n3store.countQuads(rootNode, namedNode('http://www.w3.org/ns/auth/acl#agentClass'), namedNode('http://xmlns.com/foaf/0.1/Agent'))
+    ).toBe(1)
+    expect(
+      webAC.n3store.countQuads(rootNode, namedNode('http://www.w3.org/ns/auth/acl#mode'), null)
+    ).toBe(3)
+  })
+})

--- a/__tests__/webAccessControl.integration.js
+++ b/__tests__/webAccessControl.integration.js
@@ -10,7 +10,8 @@ describe('WebAccessControl integration', () => {
   test('base container ACLs can be parsed', async  () => {
     const rootAcls = await superagent.get(rootAclUrl).accept('text/turtle')
     const rootNode = namedNode('http://platform:8080/#auth')
-    const webAC = new WebAccessControl(rootAcls.text)
+    const webAC = new WebAccessControl('', rootAcls.text)
+
     expect(
       webAC.n3store.countQuads(rootNode, namedNode('http://www.w3.org/ns/auth/acl#accessTo'), namedNode('http://platform:8080/'))
     ).toBe(1)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,13 @@
 version: "3"
 services:
-  broker:
-    image: rmohr/activemq
-    ports:
-      - 61616:61616
-      - 61613:61613
-      - 8161:8161
+  integration:
+    build:
+      context: .
+    environment:
+      INSIDE_CONTAINER: 'true'
+    command: dockerize -wait tcp://platform:8080 -wait tcp://broker:61613 -timeout 3m npm run jest-integration
+    depends_on:
+      - platform
   platform:
     image: ld4p/trellis-ext-db:latest
     environment:
@@ -17,22 +19,8 @@ services:
       - 8081:8081
     depends_on:
       - database
-      # - broker # seemingly not needed but the broker service is needed
+      - broker
       - migration
-  acl:
-    build:
-      context: .
-    command: dockerize -timeout 3m npm start
-    depends_on:
-      - platform
-  # integration:
-  #   build:
-  #     context: .
-  #   environment:
-  #     INSIDE_CONTAINER: 'true'
-  #   command: dockerize -wait tcp://platform:8080 -timeout 3m npm run integration
-  #   depends_on:
-  #     - acl
   database:
     image: postgres:latest
     environment:
@@ -42,6 +30,10 @@ services:
       PGDATA: /var/lib/postgresql/data/pgdata/mydata
     ports:
       - 5432:5432
+  broker:
+    image: rmohr/activemq
+    ports:
+      - 61613:61613
   migration:
     image: ld4p/trellis-ext-db:latest
     command: ["/opt/trellis/bin/trellis-db", "db", "migrate", "/opt/trellis/etc/config.yml"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1221,8 +1221,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -1653,7 +1652,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -1678,8 +1676,7 @@
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-      "dev": true
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1701,6 +1698,11 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -1785,7 +1787,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -1870,8 +1871,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -2585,12 +2585,16 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -2911,8 +2915,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "6.2.2",
@@ -3964,6 +3967,11 @@
         "readable-stream": "^2.0.1"
       }
     },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -3985,17 +3993,20 @@
         "to-regex": "^3.0.2"
       }
     },
+    "mime": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
+    },
     "mime-db": {
       "version": "1.38.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
-      "dev": true
+      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
     },
     "mime-types": {
       "version": "2.1.22",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
       "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
-      "dev": true,
       "requires": {
         "mime-db": "~1.38.0"
       }
@@ -4062,8 +4073,7 @@
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-      "dev": true
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -4890,8 +4900,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -5300,7 +5309,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -5331,6 +5339,39 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
+    },
+    "superagent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-4.1.0.tgz",
+      "integrity": "sha512-FT3QLMasz0YyCd4uIi5HNe+3t/onxMyEho7C3PSqmti3Twgy2rXT4fmkTz6wRL6bTF4uzPcfkUCa8u4JWHw8Ag==",
+      "requires": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.0",
+        "form-data": "^2.3.3",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^2.4.0",
+        "qs": "^6.6.0",
+        "readable-stream": "^3.0.6"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
+          "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA=="
+        },
+        "readable-stream": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
+          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "supports-color": {
       "version": "5.5.0",
@@ -5793,8 +5834,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@babel/runtime": "^7.3.4",
     "commander": "^2.19.0",
-    "n3": "^1.0.4"
+    "n3": "^1.0.4",
+    "superagent": "^4.1.0"
   }
 }


### PR DESCRIPTION
Includes:

* Add docker-compose service for running integration test in CI
* Clarify in docker-compose configuration that Trellis is dependent on ActiveMQ
* Remove docker-compose services that are not needed at this time
* Add superagent as a dependency, to handle HTTP interactions
* Update README
* Run integration test in CI
* Allow explicit boolean casts in integration tests to permit running inside and outside containerland
* Allow skipped tests in test suite

Fixes #18