### PR TITLE
Implement functions for command-line interface

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
     "plugin:jest/recommended"
   ],
   env: {
+    "es6": true,
     "jest": true,
     "node": true
   },
@@ -24,8 +25,13 @@ module.exports = {
   overrides: [
     {
       "files": ["src/**/*.js",
+                "__mocks__/**/*.js",
                 "__tests__/**/*.js"],
       "rules": {
+        // Indent `case` statements within `switch` blocks
+        "indent": ["error", 2, {
+          "SwitchCase": 1
+        }],
         // See https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-unsupported-features/es-syntax.md
         //   rule supposedly matches ECMA version with node
         //   we get: "Import and export declarations are not supported yet"
@@ -33,14 +39,16 @@ module.exports = {
         // Avoiding: "warning  Found fs.readFileSync with non literal argument ..."
         "security/detect-non-literal-fs-filename": "off",
         // Avoiding: "warning Found non-literal argument to RegExp Constructor"
-        "security/detect-non-literal-regexp": "off"
-      }
-    },
-    {
-      "files": ["src/webAccessControl.js"],
-      "rules": {
-        // we currently DO want to send errors to console
-        "no-console": "off"
+        "security/detect-non-literal-regexp": "off",
+        // this is a CLI tool; we DO want to send output to console
+        "no-console": "off",
+        // allow unused variables that begin with underscore
+        "no-unused-vars": [
+          "error",
+          {
+            "argsIgnorePattern": "^_"
+          }
+        ]
       }
     },
     {
@@ -48,7 +56,6 @@ module.exports = {
         'src/cli/*.js'
       ],
       rules: {
-        'no-console': 'off',
         'no-process-exit': 'off'
       }
     },

--- a/__mocks__/requestAlreadyExistsErrorFake.js
+++ b/__mocks__/requestAlreadyExistsErrorFake.js
@@ -1,0 +1,5 @@
+export default class RequestAlreadyExistsErrorFake {
+  post(_headers, _body) {
+    return { statusCode: 409 }
+  }
+}

--- a/__mocks__/requestNotFoundErrorFake.js
+++ b/__mocks__/requestNotFoundErrorFake.js
@@ -1,0 +1,5 @@
+export default class RequestNotFoundErrorFake {
+  post(_headers, _body) {
+    return { statusCode: 404 }
+  }
+}

--- a/__mocks__/requestOtherErrorFake.js
+++ b/__mocks__/requestOtherErrorFake.js
@@ -1,0 +1,5 @@
+export default class RequestOtherErrorFake {
+  post(_headers, _body) {
+    return { statusCode: 500, body: 'internal server error' }
+  }
+}

--- a/__mocks__/requestSuccessFake.js
+++ b/__mocks__/requestSuccessFake.js
@@ -1,0 +1,5 @@
+export default class RequestSuccessFake {
+  post(_headers, _body) {
+    return { statusCode: 201 }
+  }
+}

--- a/__tests__/cli/commander.test.js
+++ b/__tests__/cli/commander.test.js
@@ -1,30 +1,22 @@
-// Recipe for testing commander adapted from:
-//   https://medium.com/@ole.ersoy/unit-testing-commander-scripts-with-jest-bc32465709d6
 import path from 'path'
 import child from 'child_process'
 import sinopiaAcl from '../../package'
 
-// Don't actually invoke the CLI, which is tested elsewhere.
-// NOTE: Not used yet. See skips below
-//
-// import CLI from '../../src/cli/index'
-// jest.mock('../../src/cli/index')
-
-const exec = child.exec
-
+// Recipe for testing commander adapted from:
+//   https://medium.com/@ole.ersoy/unit-testing-commander-scripts-with-jest-bc32465709d6
 const cli = (args, cwd) => {
   return new Promise(resolve => {
     // NOTE: this path is relative to your current dir, not relative to this file
-    exec(`babel-node ${path.resolve('./src/cli/commander')} ${args.join(' ')}`,
-         { cwd },
-         (error, stdout, stderr) => {
-           resolve({
-             code: error && error.code ? error.code : 0,
-             error,
-             stdout,
-             stderr
-           })
-         })
+    child.exec(`babel-node ${path.resolve('./src/cli/commander')} ${args.join(' ')}`,
+      { cwd },
+      (error, stdout, stderr) => {
+        resolve({
+          code: error && error.code ? error.code : 0,
+          error,
+          stdout,
+          stderr
+        })
+      })
   })
 }
 
@@ -49,13 +41,18 @@ describe('commander', () => {
       expect(result.stderr.trim()).toBe('error: missing required argument `group\'')
     })
     test('returns 0 when command succeeds', async () => {
-      const result = await cli(['users', 'group name here'], '.')
+      const result = await cli(['users', 'group slug here'], '.')
       expect(result.code).toBe(0)
     })
     test.skip('logs error and returns 1 when command throws', async () => {
-      // TODO: fix this test. Problem: CLI instance mocked below is not
-      //       accessible to us since it's created in another process in the
-      //       `const cli` declaration above
+      // TODO: fix this test: https://github.com/LD4P/sinopia_acl/issues/38
+      //
+      // The Problem: the CLI instance mocked below is not accessible to us
+      //              since it's created in another process in the `const cli`
+      //              declaration above, so we can't vary its behavior.
+      //
+      // import CLI from '../../src/cli/index'
+      // jest.mock('../../src/cli/index')
       //
       // let errorSpy = jest.spyOn(console, 'error')
       // let errorMessage = 'it broke'
@@ -69,7 +66,7 @@ describe('commander', () => {
       //     }
       //   })
       // })
-      // const result = await cli(['users', 'group name here'], '.')
+      // const result = await cli(['users', 'group slug here'], '.')
       // expect(result.code).toBe(1)
       // expect(errorSpy).toHaveBeenCalledWith(`Error listing users: ${errorMessage}`)
     })
@@ -77,6 +74,20 @@ describe('commander', () => {
   describe('groups', () => {
     test('returns 0 when command succeeds', async () => {
       const result = await cli(['groups'], '.')
+      expect(result.code).toBe(0)
+    })
+    test.skip('logs error and returns 1 when command throws', async () => {
+      // TODO: fix this test. See related skip above in users() block.
+    })
+  })
+  describe('create', () => {
+    test('prints error and returns 1 without required arg', async () => {
+      const result = await cli(['create'], '.')
+      expect(result.code).toBe(1)
+      expect(result.stderr.trim()).toBe('error: missing required argument `group\'')
+    })
+    test('returns 0 when command succeeds', async () => {
+      const result = await cli(['create', 'group slug here'], '.')
       expect(result.code).toBe(0)
     })
     test.skip('logs error and returns 1 when command throws', async () => {

--- a/__tests__/cli/index.test.js
+++ b/__tests__/cli/index.test.js
@@ -9,19 +9,26 @@ describe('CLI', () => {
     expect(consoleSpy).toHaveBeenCalledWith('not implemented yet')
   })
   test('listUsers()', () => {
-    const group = 'http://localhost/foo'
+    const group = 'foobar'
     cli.listUsers(group)
     expect(consoleSpy).toHaveBeenCalledWith(`not implemented yet. args: ${group}`)
   })
+  test('createGroup()', () => {
+    const cliSpy = jest.spyOn(cli, 'createGroup')
+    const group = 'testingGroup'
+    cli.createGroup(group)
+    expect(consoleSpy).not.toHaveBeenCalled()
+    expect(cliSpy).toHaveBeenCalledWith(group)
+  })
   test('addUserToGroup()', () => {
     const user = 'http://sinopia.io/users/mjgiarlo'
-    const group = 'http://localhost:8080/stanford'
+    const group = 'stanford'
     cli.addUserToGroup(user, group)
     expect(consoleSpy).toHaveBeenCalledWith(`not implemented yet. args: ${user}, ${group}`)
   })
   test('removeUserFromGroup()', () => {
     const user = 'http://sinopia.io/users/mjgiarlo'
-    const group = 'http://localhost:8080/stanford'
+    const group = 'stanford'
     cli.removeUserFromGroup(user, group)
     expect(consoleSpy).toHaveBeenCalledWith(`not implemented yet. args: ${user}, ${group}`)
   })

--- a/__tests__/sinopiaClient.test.js
+++ b/__tests__/sinopiaClient.test.js
@@ -1,0 +1,48 @@
+import config from 'config'
+import SinopiaClient from '../src/sinopiaClient'
+
+// Fake out server requests
+import RequestNotFoundErrorFake from '../__mocks__/requestNotFoundErrorFake'
+import RequestAlreadyExistsErrorFake from '../__mocks__/requestAlreadyExistsErrorFake'
+import RequestOtherErrorFake from '../__mocks__/requestOtherErrorFake'
+import RequestSuccessFake from '../__mocks__/requestSuccessFake'
+
+describe('SinopiaClient', () => {
+  const client = new SinopiaClient()
+
+  describe('constructor()', () => {
+    test('returns instance with configured group container URL', () => {
+      expect(client.groupContainerUrl).toEqual(`${config.baseUrl}/repository`)
+    })
+  })
+  describe('createGroup()', () => {
+    const groupSlug = 'foobar'
+    const consoleSpy = jest.spyOn(console, 'error')
+
+    test('returns result of operation when successful', () => {
+      client.requester = new RequestSuccessFake()
+      const returned = client.createGroup(groupSlug)
+      expect(consoleSpy).not.toHaveBeenCalled()
+      expect(returned).toEqual(`${config.baseUrl}/repository/${groupSlug}`)
+
+    })
+    test('logs an error when request is a 404', () => {
+      client.requester = new RequestNotFoundErrorFake()
+      const returned = client.createGroup(groupSlug)
+      expect(consoleSpy).toHaveBeenCalledWith('error creating group: /repository container does not exist')
+      expect(returned).toBeNull()
+    })
+    test('logs an error when request is a 409', () => {
+      client.requester = new RequestAlreadyExistsErrorFake()
+      const returned = client.createGroup(groupSlug)
+      expect(consoleSpy).toHaveBeenCalledWith(`error creating group: '${groupSlug}' already exists`)
+      expect(returned).toBeNull()
+    })
+    test('logs an error when request is a 500', () => {
+      client.requester = new RequestOtherErrorFake()
+      const returned = client.createGroup(groupSlug)
+      expect(consoleSpy).toHaveBeenCalledWith('error creating group: (500) internal server error')
+      expect(returned).toBeNull()
+    })
+  })
+})

--- a/__tests__/webAccessControl.integration.js
+++ b/__tests__/webAccessControl.integration.js
@@ -1,4 +1,4 @@
-import superagent from 'superagent'
+import request from 'sync-request'
 import N3 from 'n3'
 import { WebAccessControl } from '../src/webAccessControl'
 
@@ -7,10 +7,10 @@ const { namedNode } = DataFactory
 const rootAclUrl = Boolean(process.env.INSIDE_CONTAINER) ? 'http://platform:8080/?ext=acl' : 'http://localhost:8080/?ext=acl'
 
 describe('WebAccessControl integration', () => {
-  test('base container ACLs can be parsed', async  () => {
-    const rootAcls = await superagent.get(rootAclUrl).accept('text/turtle')
+  test('base container ACLs can be parsed', () => {
+    const rootAcls = request('GET', rootAclUrl)
     const rootNode = namedNode('http://platform:8080/#auth')
-    const webAC = new WebAccessControl('', rootAcls.text)
+    const webAC = new WebAccessControl('', rootAcls.getBody('utf8'))
 
     expect(
       webAC.n3store.countQuads(rootNode, namedNode('http://www.w3.org/ns/auth/acl#accessTo'), namedNode('http://platform:8080/'))

--- a/config/default.js
+++ b/config/default.js
@@ -3,5 +3,6 @@ module.exports = {
     [
       'http://sinopia.io/users/webid4Admin1',
       'http://sinopia.io/users/webid4Admin2'
-    ]
+    ],
+  baseUrl: 'http://localhost:8080'
 }

--- a/config/test.js
+++ b/config/test.js
@@ -1,0 +1,3 @@
+module.exports = {
+
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1021,6 +1021,22 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/form-data": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
+      "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
@@ -1175,6 +1191,11 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.4",
@@ -1486,8 +1507,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "cache-base": {
       "version": "1.0.1",
@@ -1536,8 +1556,7 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "2.4.2",
@@ -1676,13 +1695,25 @@
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "config": {
       "version": "3.0.1",
@@ -1717,11 +1748,6 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "cookiejar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
-    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -1737,8 +1763,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -1805,6 +1830,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -2621,11 +2647,6 @@
         "mime-types": "^2.1.12"
       }
     },
-    "formidable": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
-      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
-    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -2658,6 +2679,11 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
+    },
+    "get-port": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
     },
     "get-stream": {
       "version": "4.1.0",
@@ -2824,6 +2850,32 @@
       "dev": true,
       "requires": {
         "whatwg-encoding": "^1.0.1"
+      }
+    },
+    "http-basic": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-8.1.1.tgz",
+      "integrity": "sha512-RRPtpg/R7HbDEoICA1MlLy0IH0D/1ShY9AcvY6U2zqT/8mjjJ893H/2URxx6JtFYEfL3IlKTkQQcKwTyLuubKA==",
+      "requires": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^1.6.2",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      }
+    },
+    "http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "requires": {
+        "@types/node": "^10.0.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.14.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.4.tgz",
+          "integrity": "sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg=="
+        }
       }
     },
     "http-signature": {
@@ -3190,8 +3242,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -4012,11 +4063,6 @@
         "readable-stream": "^2.0.1"
       }
     },
-    "methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
-    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -4037,11 +4083,6 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.2"
       }
-    },
-    "mime": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
-      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
     },
     "mime-db": {
       "version": "1.38.0",
@@ -4117,7 +4158,8 @@
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -4453,6 +4495,11 @@
         "callsites": "^3.0.0"
       }
     },
+    "parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104="
+    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -4596,14 +4643,21 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "dev": true
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
+    },
+    "promise": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.3.tgz",
+      "integrity": "sha512-HeRDUL1RJiLhyA0/grn+PTShlBAcLuh/1BJGtrvjwbvRDCTLLMEz9rOGCV+R3vHY4MixIuoMEd9Yq/XvsTPcjw==",
+      "requires": {
+        "asap": "~2.0.6"
+      }
     },
     "prompts": {
       "version": "2.0.4",
@@ -4640,8 +4694,7 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "react-is": {
       "version": "16.8.6",
@@ -4674,7 +4727,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -5408,39 +5460,6 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
-    "superagent": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-4.1.0.tgz",
-      "integrity": "sha512-FT3QLMasz0YyCd4uIi5HNe+3t/onxMyEho7C3PSqmti3Twgy2rXT4fmkTz6wRL6bTF4uzPcfkUCa8u4JWHw8Ag==",
-      "requires": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.1.2",
-        "debug": "^4.1.0",
-        "form-data": "^2.3.3",
-        "formidable": "^1.2.0",
-        "methods": "^1.1.1",
-        "mime": "^2.4.0",
-        "qs": "^6.6.0",
-        "readable-stream": "^3.0.6"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
-          "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA=="
-        },
-        "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -5455,6 +5474,24 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
       "dev": true
+    },
+    "sync-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.1.0.tgz",
+      "integrity": "sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==",
+      "requires": {
+        "http-response-object": "^3.0.1",
+        "sync-rpc": "^1.2.1",
+        "then-request": "^6.0.0"
+      }
+    },
+    "sync-rpc": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.4.tgz",
+      "integrity": "sha512-Iug+t1ICVFenUcTnDu8WXFnT+k8IVoLKGh8VA3eXUtl2Rt9SjKX3YEv33OenABqpTPL9QEaHv1+CNn2LK8vMow==",
+      "requires": {
+        "get-port": "^3.1.0"
+      }
     },
     "table": {
       "version": "5.2.3",
@@ -5617,6 +5654,31 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "then-request": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
+      "integrity": "sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==",
+      "requires": {
+        "@types/concat-stream": "^1.6.0",
+        "@types/form-data": "0.0.33",
+        "@types/node": "^8.0.0",
+        "@types/qs": "^6.2.31",
+        "caseless": "~0.12.0",
+        "concat-stream": "^1.6.0",
+        "form-data": "^2.2.0",
+        "http-basic": "^8.1.1",
+        "http-response-object": "^3.0.1",
+        "promise": "^8.0.0",
+        "qs": "^6.4.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.10.45",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.45.tgz",
+          "integrity": "sha512-tGVTbA+i3qfXsLbq9rEq/hezaHY55QxQLeXQL2ejNgFAxxrgu8eMmYIOsRcl7hN1uTLVsKOOYacV/rcJM3sfgQ=="
+        }
+      }
+    },
     "throat": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
@@ -5746,6 +5808,11 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uglify-js": {
       "version": "3.5.3",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   },
   "scripts": {
     "eslint": "eslint --color -c .eslintrc.js --ext js .",
-    "jest-cov": "jest --colors --coverage",
-    "jest-ci": "jest --colors --ci --coverage",
+    "jest-cov": "jest --colors --coverage --runInBand",
+    "jest-ci": "jest --colors --ci --coverage --runInBand",
     "jest-integration": "jest --colors --testRegex=\\.integration\\.js$",
-    "test": "jest --colors"
+    "test": "jest --colors --runInBand"
   },
   "engines": {
     "node": "10.12.x"
@@ -48,6 +48,6 @@
     "commander": "^2.19.0",
     "config": "^3.0.1",
     "n3": "^1.0.4",
-    "superagent": "^4.1.0"
+    "sync-request": "^6.1.0"
   }
 }

--- a/src/cli/commander.js
+++ b/src/cli/commander.js
@@ -10,13 +10,26 @@ commander
 
 commander
   .command('users <group>')
-  .description('List users and access controls in a group')
+  .description('List users with write access in a group')
   .action(group => {
     try {
       cli.listUsers(group)
       process.exit(0)
     } catch(error) {
       console.error(`Error listing users: ${error}`)
+      process.exit(1)
+    }
+  })
+
+commander
+  .command('create <group>')
+  .description('Create a group')
+  .action(group => {
+    try {
+      cli.createGroup(group)
+      process.exit(0)
+    } catch(error) {
+      console.error(`Error creating group: ${error}`)
       process.exit(1)
     }
   })
@@ -36,7 +49,7 @@ commander
 
 commander
   .command('add <user> <group>')
-  .description('Add user to group')
+  .description('Add user (with write access) to group')
   .action((user, group) => {
     try {
       cli.addUserToGroup(user, group)
@@ -49,7 +62,7 @@ commander
 
 commander
   .command('remove <user> <group>')
-  .description('Remove user from group')
+  .description('Remove user (with write access) from group')
   .action((user, group) => {
     try {
       cli.removeUserFromGroup(user, group)

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,4 +1,14 @@
+import SinopiaClient from '../sinopiaClient'
+
 export default class CLI {
+  constructor() {
+    this.client = new SinopiaClient()
+  }
+
+  createGroup(groupSlug) {
+    return this.client.createGroup(groupSlug)
+  }
+
   listGroups() {
     // TODO: use Sinopia client to get list of groups
     // import SinopiaServer from 'sinopia_server'
@@ -8,28 +18,28 @@ export default class CLI {
     console.log('not implemented yet')
   }
 
-  listUsers(groupUri) {
-    // TODO: get WebAccessControl instance with specified group URI
-    // const acl = new WebAccessControl(groupUri)
+  listUsers(groupSlug) {
+    // TODO: get WebAccessControl instance with specified group slug
+    // const acl = new WebAccessControl(groupSlug)
     // return acl.listUsers()
-    console.log(`not implemented yet. args: ${groupUri}`)
+    console.log(`not implemented yet. args: ${groupSlug}`)
   }
 
-  addUserToGroup(userUri, groupUri) {
+  addUserToGroup(userUri, groupSlug) {
     // TODO: use Sinopia client to add user to group
     // import SinopiaServer from 'sinopia_server'
     // const client = new SinopiaServer.LDPApi()
     // NOTE: this does not appear to be defined in the swagger spec
-    // return client.addUserToGroup(userUri, groupUri)
-    console.log(`not implemented yet. args: ${userUri}, ${groupUri}`)
+    // return client.addUserToGroup(userUri, groupSlug)
+    console.log(`not implemented yet. args: ${userUri}, ${groupSlug}`)
   }
 
-  removeUserFromGroup(userUri, groupUri) {
+  removeUserFromGroup(userUri, groupSlug) {
     // TODO: use Sinopia client to remove user from group
     // import SinopiaServer from 'sinopia_server'
     // const client = new SinopiaServer.LDPApi()
     // NOTE: this does not appear to be defined in the swagger spec
-    // return client.removeUserFromGroup(userUri, groupUri)
-    console.log(`not implemented yet. args: ${userUri}, ${groupUri}`)
+    // return client.removeUserFromGroup(userUri, groupSlug)
+    console.log(`not implemented yet. args: ${userUri}, ${groupSlug}`)
   }
 }

--- a/src/simpleRequest.js
+++ b/src/simpleRequest.js
@@ -1,0 +1,14 @@
+import request from 'sync-request'
+
+export default class SimpleRequest {
+  constructor(baseUrl) {
+    this.baseUrl = baseUrl
+  }
+
+  post(headers, body) {
+    return request('POST', this.baseUrl, {
+      headers: headers,
+      body: body
+    })
+  }
+}

--- a/src/sinopiaClient.js
+++ b/src/sinopiaClient.js
@@ -1,0 +1,38 @@
+import config from 'config'
+import SimpleRequest from './simpleRequest'
+
+export default class SinopiaClient {
+  constructor() {
+    this.groupContainerUrl = `${config.baseUrl}/repository`
+    this.requester = new SimpleRequest(this.groupContainerUrl)
+  }
+
+  createGroup(slug) {
+    try {
+      const response = this.requester.post({
+        'link': '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"',
+        'content-type': 'application/ld+json',
+        'slug': slug
+      }, `{
+        "@context": { "rdfs": "http://www.w3.org/2000/01/rdf-schema#" },
+        "@id": "",
+        "rdfs:label": "Container for ${slug} group"
+      }`)
+
+      switch(response.statusCode) {
+        case 201:
+          console.log(`group '${this.groupContainerUrl}/${slug}' created successfully`)
+          return `${this.groupContainerUrl}/${slug}`
+        case 404:
+          throw `/repository container does not exist`
+        case 409:
+          throw `'${slug}' already exists`
+        default:
+          throw `(${response.statusCode}) ${response.body.toString()}`
+      }
+    } catch(error) {
+      console.error(`error creating group: ${error}`)
+      return null
+    }
+  }
+}


### PR DESCRIPTION
connects to #32 

# Includes

* Add create group functionality (verified working)
  * **NOTE**: Does not add admin control ACLs at present
* Add `baseUrl` configuration value to hold root URL of Trellis/Sinopia server
* Create `SinopiaClient` class to return instance of API implementation
* Make synchronous HTTP requests (and in so doing dump `superagent`)
* Wrap `sync-request` dependency in small `SimpleRequest` class to isolate dependency
* Clarify that group arguments should be slugs, not fully qualified URIs
* Add test config to avoid warnings
* Run tests in band as workaround to `Jest process doesn't quit after last test completes` test suite failure
* Add `__mocks__/` to eslint coverage
* Allow `case` statements to be indented within `switch` blocks
* Disable `no-console` eslint for entire codebase (it's a CLI!)
* Add HTTP request fakes to prevent making real HTTP requests in test suite

# Follow-up work

These will be new, small issues which I'll write up, assuming that's an OK approach:

* Ensure group is created w/ admin control ACLs
* List groups in `/repository` container
* Add user to group w/ write & read ACLs
* List users in group w/ write ACL
* Remove user from group w/ write ACL
