### PR TITLE
basic auth migration script for spin up plus fixtures

### DIFF
--- a/fixtureWAC/basicAuth/groupLd4pWAC.ttl
+++ b/fixtureWAC/basicAuth/groupLd4pWAC.ttl
@@ -1,0 +1,19 @@
+PREFIX acl:  <http://www.w3.org/ns/auth/acl#>
+
+<http://platform:8080/repository/ld4p/#control>
+        acl:mode      acl:Read ;
+        acl:mode      acl:Write ;
+        acl:mode      acl:Control ;
+        acl:agent     <http://sinopia.io/users/cmharlow> ;
+        acl:accessTo  <http://platform:8080/repository/ld4p> .
+
+<http://platform:8080/repository/ld4p/#edit>
+        acl:mode      acl:Read ;
+        acl:mode      acl:Write ;
+        acl:agent     <http://sinopia.io/users/suntzu> ;
+        acl:accessTo  <http://platform:8080/repository/ld4p> .
+
+<http://platform:8080/repository/ld4p/#read>
+        acl:mode        acl:Read ;
+        acl:agentClass  <http://xmlns.com/foaf/0.1/Agent> ;
+        acl:accessTo    <http://platform:8080/repository/ld4p> .

--- a/fixtureWAC/basicAuth/migration.sh
+++ b/fixtureWAC/basicAuth/migration.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# run this script from top level of sinopia_acl, e.g.  ./fixtureWAC/basicAuth/migration.sh
+
+echo 'begin root container'
+
+curl -i -X PUT --data-binary @fixtureWAC/rootContainer.ttl -H "Content-Type:text/turtle" 'http://localhost:8080/'
+
+# echo "root container after writing container fixture"
+# curl http://localhost:8080/
+
+curl -i -X PUT --data-binary @fixtureWAC/basicAuth/rootWAC.ttl -H "Content-Type:text/turtle" 'http://localhost:8080/?ext=acl'
+
+# echo "root container ACL after writing WAC fixture"
+# curl http://localhost:8080/?ext=acl
+
+echo 'end root container'
+echo '--------------------------'
+echo 'begin repository container'
+
+curl -i -X POST --data-binary @fixtureWAC/repositoryContainer.ttl -H 'Link: <http://www.w3.org/ns/ldp#BasicContainer>; rel="type"' -H "Content-Type:text/turtle" -H "Slug:repository" 'http://localhost:8080/' -u cmharlow:S3cr3t!
+
+# echo "repository container after writing container fixture"
+# curl http://localhost:8080/repository
+
+curl -i -X PUT --data-binary @fixtureWAC/basicAuth/repositoryWAC.ttl -H "Content-Type:text/turtle" 'http://localhost:8080/repository?ext=acl' -u cmharlow:S3cr3t!
+
+# echo "repository container ACL after writing WAC fixture"
+# curl http://localhost:8080/repository?ext=acl -u cmharlow:S3cr3t!
+
+echo 'end repository container'
+echo '--------------------------'
+echo 'begin ld4p container'
+
+curl -i -X POST --data-binary @fixtureWAC/groupLd4pContainer.ttl -H 'Link: <http://www.w3.org/ns/ldp#BasicContainer>; rel="type"' -H "Content-Type:text/turtle" -H "Slug:ld4p" 'http://localhost:8080/repository' -u cmharlow:S3cr3t!
+
+# echo "ld4p container after writing container fixture"
+# curl http://localhost:8080/repository/ld4p
+
+curl -i -X PUT --data-binary @fixtureWAC/basicAuth/groupLd4pWAC.ttl -H "Content-Type:text/turtle" 'http://localhost:8080/repository/ld4p?ext=acl' -u cmharlow:S3cr3t!
+
+# echo "ld4p container ACL after writing WAC fixture"
+# curl http://localhost:8080/repository/ld4p?ext=acl -u cmharlow:S3cr3t!
+
+echo 'end ld4p container'
+echo '--------------------------'

--- a/fixtureWAC/basicAuth/repositoryWAC.ttl
+++ b/fixtureWAC/basicAuth/repositoryWAC.ttl
@@ -1,0 +1,14 @@
+PREFIX acl:  <http://www.w3.org/ns/auth/acl#>
+
+<http://platform:8080/repository/#control>
+        acl:mode      acl:Read ;
+        acl:mode      acl:Write ;
+        acl:mode      acl:Control ;
+        acl:agent     <http://sinopia.io/users/cmharlow> ;
+        acl:agent     <http://sinopia.io/users/suntzu> ;
+        acl:accessTo  <http://platform:8080/repository> .
+
+<http://platform:8080/repository/#read>
+        acl:mode        acl:Read ;
+        acl:agentClass  <http://xmlns.com/foaf/0.1/Agent> ;
+        acl:accessTo    <http://platform:8080/repository> .

--- a/fixtureWAC/basicAuth/rootWAC.ttl
+++ b/fixtureWAC/basicAuth/rootWAC.ttl
@@ -1,6 +1,6 @@
 PREFIX acl:  <http://www.w3.org/ns/auth/acl#>
 
-<http://platform:8080/#root-control>
+<http://platform:8080/#control>
         acl:mode      acl:Read ;
         acl:mode      acl:Write ;
         acl:mode      acl:Control ;
@@ -8,7 +8,7 @@ PREFIX acl:  <http://www.w3.org/ns/auth/acl#>
         acl:agent     <http://sinopia.io/users/suntzu> ;
         acl:accessTo  <http://platform:8080/> .
 
-<http://platform:8080/#root-read>
+<http://platform:8080/#read>
         acl:mode        acl:Read ;
         acl:agentClass  <http://xmlns.com/foaf/0.1/Agent> ;
         acl:accessTo    <http://platform:8080/> .

--- a/fixtureWAC/basicAuth/rootWAC.ttl
+++ b/fixtureWAC/basicAuth/rootWAC.ttl
@@ -1,0 +1,14 @@
+PREFIX acl:  <http://www.w3.org/ns/auth/acl#>
+
+<http://platform:8080/#root-control>
+        acl:mode      acl:Read ;
+        acl:mode      acl:Write ;
+        acl:mode      acl:Control ;
+        acl:agent     <http://sinopia.io/users/cmharlow> ;
+        acl:agent     <http://sinopia.io/users/suntzu> ;
+        acl:accessTo  <http://platform:8080/> .
+
+<http://platform:8080/#root-read>
+        acl:mode        acl:Read ;
+        acl:agentClass  <http://xmlns.com/foaf/0.1/Agent> ;
+        acl:accessTo    <http://platform:8080/> .

--- a/fixtureWAC/groupLd4pContainer.ttl
+++ b/fixtureWAC/groupLd4pContainer.ttl
@@ -1,0 +1,6 @@
+PREFIX ldp: <http://www.w3.org/ns/ldp#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+<>
+        a ldp:BasicContainer, ldp:Container ;
+        rdfs:label "Sinopia LD4P Group Container" .

--- a/fixtureWAC/groupLd4pWacNeedsWebids.ttl
+++ b/fixtureWAC/groupLd4pWacNeedsWebids.ttl
@@ -1,0 +1,18 @@
+PREFIX acl:  <http://www.w3.org/ns/auth/acl#>
+
+<http://platform:8080/repository/ld4p/#control>
+        acl:mode      acl:Read ;
+        acl:mode      acl:Write ;
+        acl:mode      acl:Control ;
+        acl:agent     <http://ADMIN1/WEBID> ;
+        acl:accessTo  <http://platform:8080/repository/ld4p> .
+
+<http://platform:8080/repository/ld4p/#edit>
+        acl:mode      acl:Read ;
+        acl:mode      acl:Write ;
+        acl:accessTo  <http://platform:8080/repository/ld4p> .
+
+<http://platform:8080/repository/ld4p/#read>
+        acl:mode        acl:Read ;
+        acl:agentClass  <http://xmlns.com/foaf/0.1/Agent> ;
+        acl:accessTo    <http://platform:8080/repository/ld4p> .

--- a/fixtureWAC/groupWacNeedsNameAndAdmin.ttl
+++ b/fixtureWAC/groupWacNeedsNameAndAdmin.ttl
@@ -1,18 +1,18 @@
-@prefix acl:  <http://www.w3.org/ns/auth/acl#> .
+PREFIX acl:  <http://www.w3.org/ns/auth/acl#>
 
-<http://platform:8080/repository/GROUPNAME#control>
+<http://platform:8080/repository/GROUPNAME/#control>
         acl:mode      acl:Read ;
         acl:mode      acl:Write ;
         acl:mode      acl:Control ;
         acl:agent     <http://ADMIN1/WEBID> ;
         acl:accessTo  <http://platform:8080/repository/GROUPNAME> .
 
-<http://platform:8080/repository/GROUPNAME#edit>
+<http://platform:8080/repository/GROUPNAME/#edit>
         acl:mode      acl:Read ;
         acl:mode      acl:Write ;
         acl:accessTo  <http://platform:8080/repository/GROUPNAME> .
 
-<http://platform:8080/repository/GROUPNAME#read>
+<http://platform:8080/repository/GROUPNAME/#read>
         acl:mode        acl:Read ;
         acl:agentClass  <http://xmlns.com/foaf/0.1/Agent> ;
         acl:accessTo    <http://platform:8080/repository/GROUPNAME> .

--- a/fixtureWAC/repositoryContainer.ttl
+++ b/fixtureWAC/repositoryContainer.ttl
@@ -1,0 +1,6 @@
+PREFIX ldp: <http://www.w3.org/ns/ldp#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+<>
+        a ldp:BasicContainer, ldp:Container ;
+        rdfs:label "Sinopia Repository Container" .

--- a/fixtureWAC/repositoryWacNeedsAdmins.ttl
+++ b/fixtureWAC/repositoryWacNeedsAdmins.ttl
@@ -1,13 +1,13 @@
-@prefix acl:  <http://www.w3.org/ns/auth/acl#> .
+PREFIX acl:  <http://www.w3.org/ns/auth/acl#>
 
 <http://platform:8080/repository/#control>
         acl:mode      acl:Read ;
         acl:mode      acl:Write ;
         acl:mode      acl:Control ;
         acl:agent     <http://ADMIN1/WEBID> ;
-        acl:accessTo  <http://platform:8080/repository/> .
+        acl:accessTo  <http://platform:8080/repository> .
 
 <http://platform:8080/repository/#read>
         acl:mode        acl:Read ;
         acl:agentClass  <http://xmlns.com/foaf/0.1/Agent> ;
-        acl:accessTo    <http://platform:8080/repository/> .
+        acl:accessTo    <http://platform:8080/repository> .

--- a/fixtureWAC/rootContainer.ttl
+++ b/fixtureWAC/rootContainer.ttl
@@ -1,0 +1,4 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+<http://platform:8080/>
+        rdfs:label "Sinopia LDP Root Container" .

--- a/fixtureWAC/rootWacNeedsAdmins.ttl
+++ b/fixtureWAC/rootWacNeedsAdmins.ttl
@@ -1,4 +1,4 @@
-@prefix acl:  <http://www.w3.org/ns/auth/acl#> .
+PREFIX acl:  <http://www.w3.org/ns/auth/acl#>
 
 <http://platform:8080/#root-control>
         acl:mode      acl:Read ;

--- a/fixtureWAC/rootWacNeedsAdmins.ttl
+++ b/fixtureWAC/rootWacNeedsAdmins.ttl
@@ -1,13 +1,13 @@
 PREFIX acl:  <http://www.w3.org/ns/auth/acl#>
 
-<http://platform:8080/#root-control>
+<http://platform:8080/#control>
         acl:mode      acl:Read ;
         acl:mode      acl:Write ;
         acl:mode      acl:Control ;
         acl:agent     <http://ADMIN1/WEBID> ;
         acl:accessTo  <http://platform:8080/> .
 
-<http://platform:8080/#root-read>
+<http://platform:8080/#read>
         acl:mode        acl:Read ;
         acl:agentClass  <http://xmlns.com/foaf/0.1/Agent> ;
         acl:accessTo    <http://platform:8080/> .


### PR DESCRIPTION
I have manually confirmed this script works with basic auth on the last docker image for our server that uses basic auth.

We won't be using basic auth for realz, but this gives us curl commands that work with fixture data -- something to leap off from, once we wire up appropriate cognito support via issue #33 (http plumbing with cognito)

Connects to #30