### PR TITLE
Refactor authentication client

### DIFF
--- a/__tests__/authenticateClient.test.js
+++ b/__tests__/authenticateClient.test.js
@@ -3,24 +3,137 @@ import AuthenticateClient from '../src/authenticateClient'
 import fs from 'fs'
 
 describe('AuthenticateClient', () => {
-  const client = new AuthenticateClient()
+  const username = config.get('testUser')
+  const password = process.env.AUTH_TEST_PASS
 
-  let username = config.get('testUser')
-  let password = process.env.AUTH_TEST_PASS
+  describe('constructor()', () => {
+    describe('username and password validation', () => {
+      const errmsg = 'ERROR: username and password are required (usually passed at command line)'
+      const spy = jest.spyOn(global.console, 'error')
+
+      test('logs error and throws if username is null', () => {
+        expect(() => {
+          new AuthenticateClient(null, password)
+        }).toThrow(errmsg)
+        expect(spy).toHaveBeenCalledWith(errmsg)
+      })
+
+      test('logs error and throws if username is undefined', () => {
+        expect(() => {
+          new AuthenticateClient(undefined, password)
+        }).toThrow(errmsg)
+        expect(spy).toHaveBeenCalledWith(errmsg)
+      })
+
+      test('logs error and throws if username is empty string', () => {
+        expect(() => {
+          new AuthenticateClient('', password)
+        }).toThrow(errmsg)
+        expect(spy).toHaveBeenCalledWith(errmsg)
+      })
+
+      test('logs error and throws if password is null', () => {
+        expect(() => {
+          new AuthenticateClient(username, null)
+        }).toThrow(errmsg)
+        expect(spy).toHaveBeenCalledWith(errmsg)
+      })
+
+      test('logs error and throws if password is undefined', () => {
+        expect(() => {
+          new AuthenticateClient(username, undefined)
+        }).toThrow(errmsg)
+        expect(spy).toHaveBeenCalledWith(errmsg)
+      })
+
+      test('logs error and throws if password is empty string', () => {
+        expect(() => {
+          new AuthenticateClient(username, '')
+        }).toThrow(errmsg)
+        expect(spy).toHaveBeenCalledWith(errmsg)
+      })
+    })
+    describe('userPoolId and appClientId validation', () => {
+      const errmsg = 'ERROR: userPoolId and userPoolAppClientId are required (usually in config files)'
+      const spy = jest.spyOn(global.console, 'error')
+
+      test('logs error and throws if userPoolId is null', () => {
+        AuthenticateClient.prototype.userPoolIdFromConfig = jest.fn().mockImplementation(() => {
+          return null
+        })
+        expect(() => {
+          new AuthenticateClient(username, password)
+        }).toThrow(errmsg)
+        expect(spy).toHaveBeenCalledWith(errmsg)
+      })
+
+      test('logs error and throws if userPoolId is undefined', () => {
+        AuthenticateClient.prototype.userPoolIdFromConfig = jest.fn().mockImplementation(() => {
+          return undefined
+        })
+        expect(() => {
+          new AuthenticateClient(username, password)
+        }).toThrow(errmsg)
+        expect(spy).toHaveBeenCalledWith(errmsg)
+      })
+
+      test('logs error and throws if userPoolId is empty string', () => {
+        AuthenticateClient.prototype.userPoolIdFromConfig = jest.fn().mockImplementation(() => {
+          return ''
+        })
+        expect(() => {
+          new AuthenticateClient(username, password)
+        }).toThrow(errmsg)
+        expect(spy).toHaveBeenCalledWith(errmsg)
+      })
+
+      test('logs error and throws if appClientId is null', () => {
+        AuthenticateClient.prototype.appClientIdFromConfig = jest.fn().mockImplementation(() => {
+          return null
+        })
+        expect(() => {
+          new AuthenticateClient(username, password)
+        }).toThrow(errmsg)
+        expect(spy).toHaveBeenCalledWith(errmsg)
+      })
+
+      test('logs error and throws if appClientId is undefined', () => {
+        AuthenticateClient.prototype.appClientIdFromConfig = jest.fn().mockImplementation(() => {
+          return undefined
+        })
+        expect(() => {
+          new AuthenticateClient(username, password)
+        }).toThrow(errmsg)
+        expect(spy).toHaveBeenCalledWith(errmsg)
+      })
+
+      test('logs error and throws if appClientId is empty string', () => {
+        AuthenticateClient.prototype.appClientIdFromConfig = jest.fn().mockImplementation(() => {
+          return ''
+        })
+        expect(() => {
+          new AuthenticateClient(username, password)
+        }).toThrow(errmsg)
+        expect(spy).toHaveBeenCalledWith(errmsg)
+      })
+    })
+  })
 
   describe('cognitoTokenToFile()', () => {
+    const client = new AuthenticateClient(username, password)
+
     test('creates cognitoTokenFile with JWT if it does not exist', async () => {
       if (fs.existsSync(client.cognitoTokenFile))
         fs.unlinkSync(client.cognitoTokenFile)
       expect(fs.existsSync(client.cognitoTokenFile)).toBeFalsy()
-      await client.cognitoTokenToFile(username, password)
+      await client.cognitoTokenToFile()
       expect(fs.existsSync(client.cognitoTokenFile)).toBeTruthy()
+    }, 10000)
+
+    test.skip('updates cognitoTokenFile with new JWT if it already exists with diff value', () => {
     })
 
-    test.skip('updates cognitoTokenFile with new JWT if it already exists with diff value', async () => {
-    })
-
-    test.skip('updates cognitoTokenFile even if it already has the value', async () => {
+    test.skip('updates cognitoTokenFile even if it already has the value', () => {
       // check timestamp of file?
     })
 
@@ -28,89 +141,38 @@ describe('AuthenticateClient', () => {
       const beginExpMsg = "ERROR: problem getting cognito accessToken: { code: 'UserNotFoundException',"
       const endExpMsg = "message: 'User does not exist.' }"
       const spy = jest.spyOn(global.console, 'error')
-      await client.cognitoTokenToFile('nobody', 'badpassword')
+      client.username = 'nobody'
+      client.password = 'badpassword'
+      await client.cognitoTokenToFile()
       expect(spy).toHaveBeenNthCalledWith(1, expect.stringMatching(new RegExp(beginExpMsg)))
       expect(spy).toHaveBeenNthCalledWith(1, expect.stringMatching(new RegExp(endExpMsg)))
     })
 
-    test.skip('does not touch cognitoTokenFile if no jwt is returned', async () => {
+    test.skip('does not touch cognitoTokenFile if no jwt is returned', () => {
     })
 
-    test.skip('useful error message to console error if cannot write cognitoToenFile', async () => {
-    })
-  })
-
-  describe('accessTokenPromise()', () => {
-    test('gets accessToken ', () => {
-      expect(username).toBeTruthy()
-      expect(password).toBeTruthy()
-      return client.accessTokenPromise(username, password)
-        .then((jwt) => {
-          expect(jwt).toBeTruthy()
-          expect(jwt.length).toBeGreaterThan(300)
-        })
-        .catch((err) => {
-          console.error(`problem getting accessToken in beforeEach: ${err}`)
-          expect(err).toBeFalsy()
-        })
-    }, 10000)
-
-    test.skip('error if no jwt is returned', async () => {
+    test.skip('useful error message to console if cannot write cognitoTokenFile', () => {
     })
 
-    test('logs error if no username is provided', () => {
-      const errmsg = 'ERROR: username and password are required (usually passed at command line)'
-      const spy = jest.spyOn(global.console, 'error')
-      client.accessTokenPromise(null, password)
-      expect(spy).toHaveBeenNthCalledWith(1, errmsg)
-      client.accessTokenPromise(undefined, password)
-      expect(spy).toHaveBeenNthCalledWith(2, errmsg)
-      client.accessTokenPromise('', password)
-      expect(spy).toHaveBeenNthCalledWith(3, errmsg)
-    })
+    describe('accessTokenPromise()', () => {
+      const client = new AuthenticateClient(username, password)
 
-    test('logs error if no password is provided', () => {
-      const errmsg = 'ERROR: username and password are required (usually passed at command line)'
-      const spy = jest.spyOn(global.console, 'error')
-      client.accessTokenPromise(username, null)
-      expect(spy).toHaveBeenNthCalledWith(1, errmsg)
-      client.accessTokenPromise(username, undefined)
-      expect(spy).toHaveBeenNthCalledWith(2, errmsg)
-      client.accessTokenPromise(username, '')
-      expect(spy).toHaveBeenNthCalledWith(3, errmsg)
-    })
+      test('gets accessToken ', () => {
+        return client.accessTokenPromise()
+          .then((jwt) => {
+            expect(jwt).toBeTruthy()
+            expect(jwt.length).toBeGreaterThan(300)
+          })
+          .catch((err) => {
+            console.error(`problem getting accessToken in beforeEach: ${err}`)
+            console.dir(err)
+            console.log(client.username)
+            expect(err).toBeFalsy()
+          })
+      }, 10000)
 
-    test('logs error if no userPoolId is provided', () => {
-      const errmsg = 'ERROR: userPoolId and userPoolAppClientId are required (usually in config files)'
-      const spy = jest.spyOn(global.console, 'error')
-      const prevPoolId = client.userPooldId
-      client.userPoolId = null
-      client.accessTokenPromise(username, password)
-      expect(spy).toHaveBeenNthCalledWith(1, errmsg)
-      client.userPoolId = undefined
-      client.accessTokenPromise(username, password)
-      expect(spy).toHaveBeenNthCalledWith(1, errmsg)
-      client.userPoolId = ''
-      client.accessTokenPromise(username, password)
-      expect(spy).toHaveBeenNthCalledWith(1, errmsg)
-      client.userPoolId = prevPoolId
-    })
-
-    test('logs error if no appClientId is provided', () => {
-      const errmsg = 'ERROR: userPoolId and userPoolAppClientId are required (usually in config files)'
-      const spy = jest.spyOn(global.console, 'error')
-      const prevAppClientId = client.appClientId
-      client.appClientId = null
-      client.accessTokenPromise(username, password)
-      expect(spy).toHaveBeenNthCalledWith(1, errmsg)
-      client.appClientId = undefined
-      client.accessTokenPromise(username, password)
-      expect(spy).toHaveBeenNthCalledWith(1, errmsg)
-      client.appClientId = ''
-      client.accessTokenPromise(username, password)
-      expect(spy).toHaveBeenNthCalledWith(1, errmsg)
-      client.appClientId = prevAppClientId
+      test.skip('error if no jwt is returned', () => {
+      })
     })
   })
-
 })

--- a/src/cli/authenticate.js
+++ b/src/cli/authenticate.js
@@ -26,5 +26,5 @@ prompt.start()
 prompt.get(promptConfig, (err, prompted) => {
   if (err)
     throw(err)
-  new AuthenticateClient().cognitoTokenToFile(prompted.username, prompted.password)
+  new AuthenticateClient(prompted.username, prompted.password).cognitoTokenToFile()
 })


### PR DESCRIPTION
This is a small refactoring that handles validation earlier and holds on to username and password as properties of the class, which reduces the need to pass these values around. I began this refactoring when doing the work to build a tiny authN CLI yesterday, to increase my own understanding of what was going on behind the scenes. As part of the refactoring, I also made the tests smaller and more granular.