### PR TITLE
Automatically seed Trellis when spinning up platformdata service

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,7 +62,8 @@ module.exports = {
     {
       // Allow explicit boolean casts in integration tests to permit running inside and outside containerland
       files: [
-        '__tests__/**/*.integration.js'
+        '__tests__/**/*.integration.js',
+        'src/populateEmptyTrellis.js'
       ],
       rules: {
         'no-extra-boolean-cast': 'off',

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,14 @@ WORKDIR /home/circleci
 
 COPY . .
 
+USER root
+
+# Allow circleci user to run babel-node executable
+RUN /bin/bash -c 'chown -R circleci node_modules'
+
+USER circleci
+
+# Add babel-node to PATH
+ENV PATH "$PATH:node_modules/.bin"
+
 RUN npm install

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ npm test
 If you're going to be doing active development, you'll most likely want to spin up `docker-compose` services and run integration tests separately, since you will do this multiple times while getting the code right. If so, first spin up the integration environment—Trellis & its dependencies—in the background (via `-d`) using `docker-compose`:
 
 ```shell
-$ docker-compose up -d platform
+$ docker-compose up -d platformdata
 ```
 
 To run the integration tests, they must be invoked independent of the unit tests:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,18 @@ WebACL (https://www.w3.org/wiki/WebAccessControl) is how we will gate access to 
 
 The "copy of record" of group/webID mappings will be in the Sinopia server.
 
+## Command Line
+
+This code will have a simple CLI for Sinopia Server admins to use, to be developed in a future work cycle (as of April, 2019).
+
+It will expect the admin user to have a valid JWT in a .cognitoToken file (to allow Trellis to know the admin user has permisssions to make the changes to WebACL data). You can populate this file via `bin/authenticate`, at which point you will be prompted for your Sinopia Cognito pool username and password.
+
+To spin up Trellis and its dependencies with the Sinopia container structure (root, repository, and group containers) and ACLs (declared on root container) pre-created, you can do using the `platformdata` docker-compose service:
+
+```shell
+# Add -d flag to run containers in background
+$ docker-compose up platformdata
+```
 
 ## Testing
 
@@ -16,15 +28,17 @@ To run the linter and unit tests:
 
 ```shell
 $ npm run eslint
-$ npm test
+$ AUTH_TEST_PASS=foobar npm test
 ```
+
+Note that you will need to replace the value of `AUTH_TEST_PASS` with the actual password of the Cognito testing account we have created. For that, see the Sinopia dev `shared_configs` [repository](https://github.com/sul-dlss/shared_configs/tree/sinopia-dev) or ask a fellow Sinopia developer.
 
 ### Integration
 
 If you're going to be doing active development, you'll most likely want to spin up `docker-compose` services and run integration tests separately, since you will do this multiple times while getting the code right. If so, first spin up the integration environment—Trellis & its dependencies—in the background (via `-d`) using `docker-compose`:
 
 ```shell
-$ docker-compose up -d platformdata
+$ docker-compose up -d platform
 ```
 
 To run the integration tests, they must be invoked independent of the unit tests:
@@ -45,14 +59,6 @@ Or if you just need to run the integration tests once (assuming you haven't alre
 $ docker-compose run integration
 $ docker-compose down
 ```
-
-## Command Line
-
-This code will have a simple CLI for Sinopia Server admins to use
-
-It will expect the admin user to have a JWT in an .ENV file (to allow server to know the admin user has permisssions to make the changes to WebACL data).
-
-
 
 ## Development Principles:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,17 @@ services:
     command: dockerize -wait tcp://platform:8080 -wait tcp://broker:61613 -timeout 3m npm run jest-integration
     depends_on:
       - platform
+  platformdata:
+    build:
+      context: .
+    environment:
+      INSIDE_CONTAINER: 'true'
+      TRELLIS_BASE_URL: http://platform:8080
+      COGNITO_USER_POOL_ID: ${COGNITO_USER_POOL_ID:-us-west-2_CGd9Wq136}
+      AWS_COGNITO_REGION: ${AWS_COGNITO_REGION:-us-west-2}
+    command: dockerize -wait tcp://platform:8080 -timeout 3m bin/migrate
+    depends_on:
+      - platform
   platform:
     image: ld4p/trellis-ext-db:latest
     environment:


### PR DESCRIPTION
connects to LD4P/sinopia#196

Shows a pattern that the editor and server repos can use to automatically spin up Trellis with root, repo, and group containers + the root ACLs we have specified