### PR TITLE
authenticateClient  webId(cogUserName) implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,25 @@ $ docker-compose up platformdata
 
 ## Testing
 
-To run the linter and unit tests:
+### Linter
+
+To run the linter:
 
 ```shell
 $ npm run eslint
-$ AUTH_TEST_PASS=foobar npm test
 ```
 
-Note that you will need to replace the value of `AUTH_TEST_PASS` with the actual password of the Cognito testing account we have created. For that, see the Sinopia dev `shared_configs` [repository](https://github.com/sul-dlss/shared_configs/tree/sinopia-dev) or ask a fellow Sinopia developer.
+### Unit tests
+
+To run unit tests:
+
+```shell
+$ AUTH_TEST_PASS=foobar AWS_PROFILE=barfoo npm test
+```
+
+Note that you will need to replace the value of
+-  `AUTH_TEST_PASS` with the actual password of the Cognito testing account we have created. For that, see the Sinopia dev `shared_configs` [repository](https://github.com/sul-dlss/shared_configs/tree/sinopia-dev) or ask a fellow Sinopia developer.
+- `AWS_PROFILE` with the value of your developer profile, e.g. 'dev' or 'my-id@sul-dlss-dev'
 
 ### Integration
 

--- a/__tests__/authenticateClient.test.js
+++ b/__tests__/authenticateClient.test.js
@@ -175,4 +175,21 @@ describe('AuthenticateClient', () => {
       })
     })
   })
+
+  describe('webId()', () => {
+    const client = new AuthenticateClient(username, password)
+    const desiredUser = config.get('testUser')
+
+    test('returns valid webId', async () => {
+      const webid = await client.webId(desiredUser)
+      const startsWithRegex = new RegExp(`^${config.get('webidBaseUrl')}/${config.get('userPoolId')}/`)
+      expect(webid).toMatch(startsWithRegex)
+      const endsWithUuidRegex = new RegExp("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+      expect(webid).toMatch(endsWithUuidRegex)
+    }, 10000)
+
+    test.skip('throws error and console logs if problem', async() => {
+    })
+  })
+
 })

--- a/__tests__/sinopiaClient.test.js
+++ b/__tests__/sinopiaClient.test.js
@@ -12,7 +12,7 @@ describe('SinopiaClient', () => {
 
   describe('constructor()', () => {
     test('returns instance with configured group container URL', () => {
-      expect(client.groupContainerUrl).toEqual(`${config.baseUrl}/repository`)
+      expect(client.groupContainerUrl).toEqual(`${config.get('baseUrl')}/repository`)
     })
   })
   describe('createGroup()', () => {
@@ -23,7 +23,7 @@ describe('SinopiaClient', () => {
       client.requester = new RequestSuccessFake()
       const returned = client.createGroup(groupSlug)
       expect(consoleSpy).not.toHaveBeenCalled()
-      expect(returned).toEqual(`${config.baseUrl}/repository/${groupSlug}`)
+      expect(returned).toEqual(`${config.get('baseUrl')}/repository/${groupSlug}`)
 
     })
     test('logs an error when request is a 404', () => {

--- a/config/default.js
+++ b/config/default.js
@@ -28,7 +28,8 @@ module.exports = {
   userPoolId: 'us-west-2_CGd9Wq136',
   userPoolAppClientId: '2u6s7pqkc1grq1qs464fsi82at',
   cognitoTokenFile: '.cognitoToken',
-  webidBaseUrl: 'https://cognito-idp.us-west-2.amazonaws.com',
+  awsRegion: 'us-west-2',
+  webidBaseUrl: 'https://cognito-idp.us-west-2.amazonaws.com', // no trailing slash
   groups: {
     alberta: 'University of Alberta',
     boulder: 'University of Colorado, Boulder',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1192,6 +1192,34 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "aws-sdk": {
+      "version": "2.437.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.437.0.tgz",
+      "integrity": "sha512-sDZb5QBOO6FOMvuKDEdO16YQRk0WUhnQd38EaSt0yUCi4Gev8uypODyYONgODZcXe8Cr1GMwC8scUKr00S/I5w==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "ieee754": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+          "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+        },
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        }
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -2271,6 +2299,11 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "exec-sh": {
       "version": "0.3.2",
@@ -3738,6 +3771,11 @@
         }
       }
     },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
     "js-cookie": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.0.tgz",
@@ -4678,6 +4716,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
     "react-is": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
@@ -5042,8 +5085,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
       "version": "5.6.0",
@@ -5931,6 +5973,22 @@
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
+    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -5975,8 +6033,7 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8flags": {
       "version": "3.1.2",
@@ -6195,6 +6252,20 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@babel/preset-env": "^7.3.4",
     "@babel/runtime": "^7.3.4",
     "amazon-cognito-identity-js": "^3.0.10",
+    "aws-sdk": "^2.437.0",
     "commander": "^2.19.0",
     "config": "^3.0.1",
     "mustache": "^3.0.1",

--- a/src/populateEmptyTrellis.js
+++ b/src/populateEmptyTrellis.js
@@ -4,17 +4,18 @@ import Mustache from 'mustache'
 import request from 'sync-request'
 import sleep from 'sleep'
 
-const baseUrl = Boolean(process.env.INSIDE_CONTAINER) ? 'http://platform:8080' : config.baseUrl
+const baseUrl = Boolean(process.env.INSIDE_CONTAINER) ? 'http://platform:8080' : config.get('baseUrl')
 
 const renderTemplateFile = (templatePath, templateValues) => {
   const template = fs.readFileSync(templatePath, 'utf8')
   return Mustache.render(template, templateValues)
 }
 
-console.log(`retrieving token from ${config.cognitoTokenFile}`)
+const cogTokenFile = config.get('cognitoTokenFile')
+console.log(`retrieving token from ${cogTokenFile}`)
 
-const token = (fs.existsSync(config.cognitoTokenFile)) ?
-  fs.readFileSync(config.cognitoTokenFile, 'utf8').trim() :
+const token = (fs.existsSync(cogTokenFile)) ?
+  fs.readFileSync(cogTokenFile, 'utf8').trim() :
   ''
 
 console.log('creating root container')
@@ -54,7 +55,7 @@ if (response.statusCode == 404) {
   })
 }
 
-Object.entries(config.groups).forEach(([slug, label]) => {
+Object.entries(config.get('groups')).forEach(([slug, label]) => {
   // Pause between requests to give Trellis time to persist data
   sleep.sleep(1)
 
@@ -99,7 +100,7 @@ request('PATCH', `${baseUrl}/?ext=acl`, {
     'Authorization': `Bearer ${token}`
   },
   body: renderTemplateFile('./fixtureWAC/rootWAC.sparql.mustache', {
-    adminAgents: config.adminUsers.map(webid => {
+    adminAgents: config.get('adminUsers').map(webid => {
       return `    </#control> acl:agent <${webid}> .`
     }).join("\n")
   })

--- a/src/sinopiaClient.js
+++ b/src/sinopiaClient.js
@@ -3,7 +3,7 @@ import SimpleRequest from './simpleRequest'
 
 export default class SinopiaClient {
   constructor() {
-    this.groupContainerUrl = `${config.baseUrl}/repository`
+    this.groupContainerUrl = `${config.get('baseUrl')}/repository`
     this.requester = new SimpleRequest(this.groupContainerUrl)
   }
 

--- a/src/webAccessControl.js
+++ b/src/webAccessControl.js
@@ -94,14 +94,15 @@ export class WebAccessControl {
     if (this.controlWebIds().length == 0)
       throw "invalid WAC: no webIds with control permission"
 
+    const adminUsers = config.get('adminUsers')
     this.controlWebIds().every(controlWebId => {
-      if (!config.adminUsers.includes(controlWebId))
+      if (!adminUsers.includes(controlWebId))
         throw `invalid WAC: non-admin webId has control permission: ${controlWebId}`
     })
 
-    // we need to do more checking if there are more config.adminUsers than controlWebIds
-    if (config.adminUsers.length > this.controlWebIds().length) {
-      config.adminUsers.forEach(webId => {
+    // we need to do more checking if there are more adminUsers than controlWebIds
+    if (adminUsers.length > this.controlWebIds().length) {
+      adminUsers.forEach(webId => {
         if (!this.controlWebIds().includes(webId))
           throw `invalid WAC: admin does not have control permission: ${webId}`
       })


### PR DESCRIPTION
Use aws-sdk and pieces from amplify-js npm packages to get current webid given cognito username.

Requires an AWS account will appropriate permissions;  happy to add more info to readme.

README shows how to run tests locally;  circleci has been set up with a user so tests can pass there as well.

Bonus:  switch to consistently using `config.get('varname')` over `config.varname` as I read somewhere that it was ... better for some reason.

Note that I am have created issue #56 to leverage this code in `populateEmptyTrellis`

closes #29 