### PR TITLE
populateEmptyTrellis gets webids from usernames (with some temporary hardcoding)

### DIFF
--- a/__tests__/__fixtures__/rootAclValid.ttl
+++ b/__tests__/__fixtures__/rootAclValid.ttl
@@ -4,8 +4,8 @@
         acl:mode      acl:Read ;
         acl:mode      acl:Write ;
         acl:mode      acl:Control ;
-        acl:agent     <http://sinopia.io/users/webid4Admin1> ;
-        acl:agent     <http://sinopia.io/users/webid4Admin2> ;
+        acl:agent     <https://cognito-idp.us-west-2.amazonaws.com/us-west-2_CGd9Wq136/789dda7d-25c0-4a8f-9c62-b3116a97cc9b> ;
+        acl:agent     <https://cognito-idp.us-west-2.amazonaws.com/us-west-2_CGd9Wq136/56b84999-793f-4fa6-ad20-be8f62a5c2de> ;
         acl:accessTo  <http://platform:8080/> .
 
 <http://platform:8080/#root-read>

--- a/__tests__/__fixtures__/testGroupAcl_1Control.ttl
+++ b/__tests__/__fixtures__/testGroupAcl_1Control.ttl
@@ -4,15 +4,14 @@
         acl:mode      acl:Read ;
         acl:mode      acl:Write ;
         acl:mode      acl:Control ;
-        acl:agent     <http://sinopia.io/users/webid4Admin1> ;
+        acl:agent     <https://cognito-idp.us-west-2.amazonaws.com/us-west-2_CGd9Wq136/789dda7d-25c0-4a8f-9c62-b3116a97cc9b> ;
         acl:accessTo  <http://platform:8080/test> .
 
 <http://platform:8080/#test-edit>
-        acl:mode      acl:Read ;
-        acl:mode      acl:Write ;
-        acl:agent     <http://sinopia.io/users/cmharlow> ;
-        acl:agent     <http://sinopia.io/users/suntzu> ;
-        acl:accessTo  <http://platform:8080/test> .
+        acl:mode        acl:Read ;
+        acl:mode        acl:Write ;
+        acl:agentClass  acl:AuthenticatedAgent ;
+        acl:accessTo    <http://platform:8080/test> .
 
 <http://platform:8080/#test-read>
         acl:mode        acl:Read ;

--- a/__tests__/__fixtures__/testGroupAcl_2Control.ttl
+++ b/__tests__/__fixtures__/testGroupAcl_2Control.ttl
@@ -4,16 +4,15 @@
         acl:mode      acl:Read ;
         acl:mode      acl:Write ;
         acl:mode      acl:Control ;
-        acl:agent     <http://sinopia.io/users/webid4Admin1> ;
-        acl:agent     <http://sinopia.io/users/webid4Admin2> ;
+        acl:agent     <https://cognito-idp.us-west-2.amazonaws.com/us-west-2_CGd9Wq136/789dda7d-25c0-4a8f-9c62-b3116a97cc9b> ;
+        acl:agent     <https://cognito-idp.us-west-2.amazonaws.com/us-west-2_CGd9Wq136/56b84999-793f-4fa6-ad20-be8f62a5c2de> ;
         acl:accessTo  <http://platform:8080/test> .
 
 <http://platform:8080/#test-edit>
-        acl:mode      acl:Read ;
-        acl:mode      acl:Write ;
-        acl:agent     <http://sinopia.io/users/cmharlow> ;
-        acl:agent     <http://sinopia.io/users/suntzu> ;
-        acl:accessTo  <http://platform:8080/test> .
+        acl:mode        acl:Read ;
+        acl:mode        acl:Write ;
+        acl:agentClass  acl:AuthenticatedAgent ;
+        acl:accessTo    <http://platform:8080/test> .
 
 <http://platform:8080/#test-read>
         acl:mode        acl:Read ;

--- a/__tests__/webAccessControl.integration.js
+++ b/__tests__/webAccessControl.integration.js
@@ -7,7 +7,7 @@ const { namedNode } = DataFactory
 const rootAclUrl = Boolean(process.env.INSIDE_CONTAINER) ? 'http://platform:8080/?ext=acl' : 'http://localhost:8080/?ext=acl'
 
 describe('WebAccessControl integration', () => {
-  test('base container ACLs can be parsed', () => {
+  test('root container ACLs can be parsed', () => {
     const rootAcls = request('GET', rootAclUrl)
     const rootNode = namedNode('http://platform:8080/#auth')
     const webAC = new WebAccessControl('', rootAcls.getBody('utf8'))

--- a/__tests__/webAccessControl.test.js
+++ b/__tests__/webAccessControl.test.js
@@ -23,18 +23,18 @@ describe('WebAccessControl', () => {
   })
 
   it('no need to call parseWac when wac string passed in constructor', () => {
-    const wac = new WebAccessControl('', fs.readFileSync(`${fixture_dir}/cmharlowBaseAcl.ttl`).toString())
-    expect(wac.hasControlWebId('http://sinopia.io/users/cmharlow')).toBeTruthy()
+    const basicAuthWac = new WebAccessControl('', fs.readFileSync(`${fixture_dir}/cmharlowBaseAcl.ttl`).toString())
+    expect(basicAuthWac.hasControlWebId('http://sinopia.io/users/cmharlow')).toBeTruthy()
     expect(myWac.hasControlWebId('http://example.com/nobody')).toBeFalsy()
   })
 
   describe('controlWebIds()', () => {
     it('lists the webids with control access', () => {
-      myWac.parseWac(fs.readFileSync(`${fixture_dir}/testGroupAcl_1Control1Write.ttl`).toString())
-      expect(myWac.controlWebIds()).toEqual(['http://sinopia.io/users/cmharlow'])
-
-      myWac.parseWac(fs.readFileSync(`${fixture_dir}/cmharlowBaseAcl.ttl`).toString())
-      expect(myWac.controlWebIds()).toEqual(['http://sinopia.io/users/cmharlow'])
+      const jwtWac = new WebAccessControl()
+      jwtWac.parseWac(fs.readFileSync(`${fixture_dir}/testGroupAcl_2Control.ttl`).toString())
+      expect(jwtWac.controlWebIds().length).toBe(2)
+      expect(jwtWac.controlWebIds()).toContain('https://cognito-idp.us-west-2.amazonaws.com/us-west-2_CGd9Wq136/789dda7d-25c0-4a8f-9c62-b3116a97cc9b')
+      expect(jwtWac.controlWebIds()).toContain('https://cognito-idp.us-west-2.amazonaws.com/us-west-2_CGd9Wq136/56b84999-793f-4fa6-ad20-be8f62a5c2de')
     })
 
     it('empty array when the wac has no control access (does not error)', () => {
@@ -81,22 +81,23 @@ describe('WebAccessControl', () => {
 
   describe('hasControlWebId()', () => {
     describe('ttl fixture', () => {
-      const otherWac = new WebAccessControl()
+      const jwtWac = new WebAccessControl()
+      const basicAuthWac = new WebAccessControl()
       beforeAll(() => {
-        myWac.parseWac(fs.readFileSync(`${fixture_dir}/cmharlowBaseAcl.ttl`).toString())
-        otherWac.parseWac(fs.readFileSync(`${fixture_dir}/testGroupAcl_1Control1Write.ttl`).toString())
+        basicAuthWac.parseWac(fs.readFileSync(`${fixture_dir}/cmharlowBaseAcl.ttl`).toString())
+        jwtWac.parseWac(fs.readFileSync(`${fixture_dir}/testGroupAcl_1Control.ttl`).toString())
       })
 
       it('true when user has control access', () => {
-        expect(myWac.hasControlWebId('http://sinopia.io/users/cmharlow')).toBeTruthy()
-        expect(otherWac.hasControlWebId('http://sinopia.io/users/cmharlow')).toBeTruthy()
+        expect(jwtWac.hasControlWebId('https://cognito-idp.us-west-2.amazonaws.com/us-west-2_CGd9Wq136/789dda7d-25c0-4a8f-9c62-b3116a97cc9b')).toBeTruthy()
+        expect(basicAuthWac.hasControlWebId('http://sinopia.io/users/cmharlow')).toBeTruthy()
       })
       it('false when user has write, but not control, access', () => {
-        expect(otherWac.hasControlWebId('http://sinopia.io/users/suntzu')).toBeFalsy()
+        expect(jwtWac.hasControlWebId('https://cognito-idp.us-west-2.amazonaws.com/us-west-2_CGd9Wq136/56b84999-793f-4fa6-ad20-be8f62a5c2de')).toBeFalsy()
       })
       it('false when user does not have control access', () => {
-        expect(myWac.hasControlWebId('http://example.com/nobody')).toBeFalsy()
-        expect(otherWac.hasControlWebId('http://example.com/nobody')).toBeFalsy()
+        expect(jwtWac.hasControlWebId('http://example.com/nobody')).toBeFalsy()
+        expect(basicAuthWac.hasControlWebId('http://example.com/nobody')).toBeFalsy()
       })
     })
 
@@ -116,21 +117,21 @@ describe('WebAccessControl', () => {
 
   describe('hasWriteWebId()', () => {
     describe('ttl fixture', () => {
-      const otherWac = new WebAccessControl()
+      const jwtWac = new WebAccessControl()
       beforeAll(() => {
         myWac.parseWac(fs.readFileSync(`${fixture_dir}/cmharlowBaseAcl.ttl`).toString())
-        otherWac.parseWac(fs.readFileSync(`${fixture_dir}/testGroupAcl_1Control1Write.ttl`).toString())
+        jwtWac.parseWac(fs.readFileSync(`${fixture_dir}/testGroupAcl_1Control1Write.ttl`).toString())
       })
 
       it('true when user has write (but not control) access', () => {
-        expect(otherWac.hasWriteWebId('http://sinopia.io/users/suntzu')).toBeTruthy()
+        expect(jwtWac.hasWriteWebId('http://sinopia.io/users/suntzu')).toBeTruthy()
       })
       it('false when user has control access', () => {
-        expect(otherWac.hasWriteWebId('http://sinopia.io/users/cmharlow')).toBeFalsy()
+        expect(jwtWac.hasWriteWebId('http://sinopia.io/users/cmharlow')).toBeFalsy()
       })
       it('false when user does not have write access', () => {
-        expect(otherWac.hasWriteWebId('http://example.com/nobody')).toBeFalsy()
         expect(myWac.hasWriteWebId('http://example.com/nobody')).toBeFalsy()
+        expect(jwtWac.hasWriteWebId('http://example.com/nobody')).toBeFalsy()
       })
     })
 
@@ -149,102 +150,105 @@ describe('WebAccessControl', () => {
   })
 
   describe('validates()', () => {
-    it('throws error when there is no acl:accessTo predicate', () => {
+    it('throws error when there is no acl:accessTo predicate', async () => {
+      expect.assertions(1)
       const wac = new WebAccessControl('myGroup', fs.readFileSync(`${fixture_dir}/noAccessToPredicate.ttl`).toString())
-      expect(() => {
-        wac.validates()
-      }).toThrow('invalid WAC: no http://www.w3.org/ns/auth/acl#accessTo predicate')
+      await expect(wac.validates()).rejects.toEqual('invalid WAC: no http://www.w3.org/ns/auth/acl#accessTo predicate')
     })
-    it('throws error when there is no acl:agentClass predicate', () => {
+    it('throws error when there is no acl:agentClass predicate', async () => {
+      expect.assertions(1)
       const wac = new WebAccessControl('myGroup', fs.readFileSync(`${fixture_dir}/noAgentClassPredicate.ttl`).toString())
-      expect(() => {
-        wac.validates()
-      }).toThrow('invalid WAC: no http://www.w3.org/ns/auth/acl#agentClass predicate')
+      await expect(wac.validates()).rejects.toEqual('invalid WAC: no http://www.w3.org/ns/auth/acl#agentClass predicate')
     })
-    it('throws error when there is no acl:mode acl:Read predicate-object pair', () => {
+    it('throws error when there is no acl:mode acl:Read predicate-object pair', async () => {
+      expect.assertions(1)
       const wac = new WebAccessControl('myGroup', fs.readFileSync(`${fixture_dir}/noAclReadIncluded.ttl`).toString())
-      expect(() => {
-        wac.validates()
-      }).toThrow('invalid WAC: no http://www.w3.org/ns/auth/acl#Read permissions')
+      await expect(wac.validates()).rejects.toEqual('invalid WAC: no http://www.w3.org/ns/auth/acl#Read permissions')
     })
-    it('throws error when a group has no acl:agent predicate', () => {
+    it('throws error when a group has no acl:agent predicate', async () => {
+      // NOTE: we are no longer doing WAC for group containers
+      expect.assertions(1)
       const wac = new WebAccessControl('stanford', fs.readFileSync(`${fixture_dir}/noGroupUsers.ttl`).toString())
-      expect(() => {
-        wac.validates()
-      }).toThrow('invalid WAC: group container requires http://www.w3.org/ns/auth/acl#agent webids')
+      await expect(wac.validates()).rejects.toEqual('invalid WAC: group container requires http://www.w3.org/ns/auth/acl#agent webids')
     })
-    it('throws error when group in constructor does not match object of acl:accessTo predicate', () => {
+    it('throws error when group in constructor does not match object of acl:accessTo predicate', async () => {
+      // NOTE: we are no longer doing WAC for group containers
+      expect.assertions(1)
       const wac = new WebAccessControl('myGroup', fs.readFileSync(`${fixture_dir}/stanfordGroupAcl_2Users.ttl`).toString())
-      expect(() => {
-        wac.validates()
-      }).toThrow('invalid WAC: acl:accessTo expected group "myGroup"; found "stanford"')
+      expect(wac.validates()).rejects.toEqual('invalid WAC: acl:accessTo expected group "myGroup"; found "stanford"')
     })
-    it('returns true when this.n3store root container contents pass validation', () => {
+    it('returns true when this.n3store root container contents pass validation', async () => {
+      expect.assertions(1)
       const wac = new WebAccessControl('myGroup', fs.readFileSync(`${fixture_dir}/rootAclValid.ttl`).toString())
-      expect(wac.validates()).toBeTruthy()
+      await expect(wac.validates()).resolves.toBeTruthy()
     })
-    it('returns true when this.n3store group container contents pass validation', () => {
-      const wac = new WebAccessControl('test', fs.readFileSync(`${fixture_dir}/testGroupAcl_2Control2Write.ttl`).toString())
-      expect(wac.validates()).toBeTruthy()
+    it('returns true when this.n3store group container contents pass validation', async () => {
+      // NOTE: we are no longer doing WAC for group containers
+      expect.assertions(1)
+      const wac = new WebAccessControl('test', fs.readFileSync(`${fixture_dir}/testGroupAcl_2Control.ttl`).toString())
+      await expect(wac.validates()).resolves.toBeTruthy()
     })
   })
 
   describe('assertAdminControl()', () => {
-    it('throws error if non-admin webId has acl:Control permission', () => {
+    it('throws error if non-admin webId has acl:Control permission', async () => {
+      expect.assertions(1)
+      const myWac = new WebAccessControl()
       myWac.parseWac(fs.readFileSync(`${fixture_dir}/cmharlowBaseAcl.ttl`).toString())
-      expect(() => {
-        myWac.assertAdminControl()
-      }).toThrow('invalid WAC: non-admin webId has control permission: http://sinopia.io/users/cmharlow')
+      await expect(myWac.assertAdminControl()).rejects.toEqual('invalid WAC: non-admin webId has control permission: http://sinopia.io/users/cmharlow')
     })
-    it('throws error if admin webId does NOT have acl:Control permission', () => {
-      myWac.parseWac(fs.readFileSync(`${fixture_dir}/testGroupAcl_1Control2Write.ttl`).toString())
-      expect(() => {
-        myWac.assertAdminControl()
-      }).toThrow('invalid WAC: admin does not have control permission: ')
+    it('throws error if admin webId does NOT have acl:Control permission', async () => {
+      expect.assertions(1)
+      const myWac = new WebAccessControl()
+      myWac.parseWac(fs.readFileSync(`${fixture_dir}/testGroupAcl_1Control.ttl`).toString())
+      await expect(myWac.assertAdminControl()).rejects.toEqual('invalid WAC: admin does not have control permission: https://cognito-idp.us-west-2.amazonaws.com/us-west-2_CGd9Wq136/56b84999-793f-4fa6-ad20-be8f62a5c2de')
     })
-    it('does not throw error if all admin users, and only admin users have acl:Control', () => {
-      myWac.parseWac(fs.readFileSync(`${fixture_dir}/testGroupAcl_2Control2Write.ttl`).toString())
-      expect(() => {
-        myWac.assertAdminControl()
-      }).not.toThrow()
+    it('does not throw error if all admin users, and only admin users have acl:Control', async () => {
+      expect.assertions(1)
+      const myWac = new WebAccessControl()
+      myWac.parseWac(fs.readFileSync(`${fixture_dir}/testGroupAcl_2Control.ttl`).toString())
+      // the following will fail if the promise rejects
+      await expect(myWac.assertAdminControl()).resolves.toBeUndefined()
     })
-    it('throws error if no control users', () => {
+    it('throws error if no control users', async () => {
+      expect.assertions(1)
+      const myWac = new WebAccessControl()
       myWac.parseWac(fs.readFileSync(`${fixture_dir}/noControl.ttl`).toString())
-      expect(() => {
-        myWac.assertAdminControl()
-      }).toThrow('invalid WAC: no webIds with control permission')
+      await expect(myWac.assertAdminControl()).rejects.toEqual('invalid WAC: no webIds with control permission')
     })
-    it('throws error when the wac is an empty string', () => {
+    it('throws error when the wac is an empty string', async () => {
+      expect.assertions(1)
       const wac = new WebAccessControl()
       wac.parseWac('')
-      expect(() => {
-        myWac.assertAdminControl()
-      }).toThrow('invalid WAC: no webIds with control permission')
+      await expect(myWac.assertAdminControl()).rejects.toEqual('invalid WAC: no webIds with control permission')
     })
-    it('throws error when no wac is parsed', () => {
-      expect(() => {
-        myWac.assertAdminControl()
-      }).toThrow('invalid WAC: no webIds with control permission')
+    it('throws error when no wac is parsed', async () => {
+      expect.assertions(1)
+      const myWac = new WebAccessControl()
+      // the following will fail if the promise resolves
+      await expect(myWac.assertAdminControl()).rejects.toBeTruthy()
     })
   })
 
   describe('asTtl()', () => {
-    it('writes console error when this.n3store does not pass validation', () => {
+    it('writes console error when this.n3store does not pass validation', async () => {
+      expect.assertions(1)
       const spy = jest.spyOn(global.console, 'error')
       const wac = new WebAccessControl('stanford', fs.readFileSync(`${fixture_dir}/noGroupUsers.ttl`).toString())
-      wac.asTtl()
+      await wac.asTtl()
       const origMsg = 'invalid WAC: group container requires http://www.w3.org/ns/auth/acl#agent webids'
       const expMsg = `Unable to create WebAccessControl ttl to send to Sinopia server due to ${origMsg}`
       expect(spy).toHaveBeenCalledWith(expMsg)
     })
-    it('returns a string containing ttl matching contents of this.n3store', () => {
-      const wac = new WebAccessControl('test', fs.readFileSync(`${fixture_dir}/testGroupAcl_2Control2Write.ttl`).toString())
-      const outputTtlFile = wac.asTtl()
+    it('returns a string containing ttl matching contents of this.n3store', async () => {
+      expect.assertions(16)
+      const wac = new WebAccessControl('test', fs.readFileSync(`${fixture_dir}/testGroupAcl_2Control.ttl`).toString())
+      const outputTtlFile = await wac.asTtl()
       const myStore = N3.Store()
       myStore.addQuads(N3.Parser().parse(outputTtlFile))
 
       expect(myStore.countQuads()).toEqual(wac.n3store.countQuads())
-      expect(myStore.countQuads()).toBe(14)
+      expect(myStore.countQuads()).toBe(13)
 
       const testGroupNode = namedNode('http://platform:8080/test')
       const controlNode = namedNode('http://platform:8080/#test-control')
@@ -254,15 +258,14 @@ describe('WebAccessControl', () => {
       expect(myStore.countQuads(controlNode, wac.aclModeNode(), wac.aclReadNode())).toBe(1)
       expect(myStore.countQuads(controlNode, wac.aclModeNode(), wac.aclWriteNode())).toBe(1)
       expect(myStore.countQuads(controlNode, wac.aclModeNode(), wac.aclControlNode())).toBe(1)
-      expect(myStore.countQuads(controlNode, wac.aclAgentNode(), namedNode('http://sinopia.io/users/webid4Admin1'))).toBe(1)
-      expect(myStore.countQuads(controlNode, wac.aclAgentNode(), namedNode('http://sinopia.io/users/webid4Admin2'))).toBe(1)
+      expect(myStore.countQuads(controlNode, wac.aclAgentNode(), namedNode('https://cognito-idp.us-west-2.amazonaws.com/us-west-2_CGd9Wq136/789dda7d-25c0-4a8f-9c62-b3116a97cc9b'))).toBe(1)
+      expect(myStore.countQuads(controlNode, wac.aclAgentNode(), namedNode('https://cognito-idp.us-west-2.amazonaws.com/us-west-2_CGd9Wq136/56b84999-793f-4fa6-ad20-be8f62a5c2de'))).toBe(1)
       expect(myStore.countQuads(controlNode, wac.aclAccessToNode(), testGroupNode)).toBe(1)
 
       expect(myStore.countQuads(editNode, wac.aclModeNode(), wac.aclReadNode())).toBe(1)
       expect(myStore.countQuads(editNode, wac.aclModeNode(), wac.aclWriteNode())).toBe(1)
       expect(myStore.countQuads(editNode, wac.aclModeNode(), wac.aclControlNode())).toBe(0)
-      expect(myStore.countQuads(editNode, wac.aclAgentNode(), namedNode('http://sinopia.io/users/cmharlow'))).toBe(1)
-      expect(myStore.countQuads(editNode, wac.aclAgentNode(), namedNode('http://sinopia.io/users/suntzu'))).toBe(1)
+      expect(myStore.countQuads(editNode, wac.aclAgentClassNode(), namedNode('http://www.w3.org/ns/auth/acl#AuthenticatedAgent'))).toBe(1)
       expect(myStore.countQuads(editNode, wac.aclAccessToNode(), testGroupNode)).toBe(1)
 
       expect(myStore.countQuads(readOnlyNode, wac.aclModeNode(), wac.aclReadNode())).toBe(1)

--- a/config/default.js
+++ b/config/default.js
@@ -2,34 +2,21 @@
 const defer = require('config/defer').deferConfig
 
 module.exports = {
-  // This is a list of WebIDs from the Sinopia Cognito user pool (in development
-  // environment). The IDs in this list are, in no order, for:
-  //
-  // * mjgiarlo
-  // * jpnelson
-  // * ndushay
-  // * michellef
-  // * suntzu
-  //
-  // (could not find account for jgreben)
-  adminUsers: defer(function () {
-    return [
-      '62748a6a-3a53-4b4c-976d-aac6062d594b',
-      '90c16e02-3fdd-4459-968e-f4795b682bd0',
-      '11a584b8-2ae5-4fd1-b8a1-e28976c48132',
-      '56b84999-793f-4fa6-ad20-be8f62a5c2de',
-      '2586583c-44bd-4d3c-9a6a-0d94510be5ea'
-    ].map(sub => {
-      return `${this.webidBaseUrl}/${this.userPoolId}/${sub}`
-    })
-  }),
   baseUrl: 'http://localhost:8080',
-  // authorization
-  userPoolId: 'us-west-2_CGd9Wq136',
-  userPoolAppClientId: '2u6s7pqkc1grq1qs464fsi82at',
+  // usernames from the development Sinopia Cognito user pool (same names used in stage and prod Cogntio pools)
+  adminUsers: [
+    'jgreben',
+    'jpnelson',
+    'michelle',
+    'mjgiarlo',
+    'ndushay',
+    'suntzu'
+  ],
+  userPoolId: 'us-west-2_CGd9Wq136', // development
+  userPoolAppClientId: '2u6s7pqkc1grq1qs464fsi82at', // development
   cognitoTokenFile: '.cognitoToken',
   awsRegion: 'us-west-2',
-  webidBaseUrl: 'https://cognito-idp.us-west-2.amazonaws.com', // no trailing slash
+  webidBaseUrl: defer(function () { return `https://cognito-idp.${this.awsRegion}.amazonaws.com` }), // no trailing slash
   groups: {
     alberta: 'University of Alberta',
     boulder: 'University of Colorado, Boulder',

--- a/config/test.js
+++ b/config/test.js
@@ -2,7 +2,7 @@ module.exports = {
   testUser: 'sinopia-devs_client-tester',
   // override the default value for testing
   adminUsers: [
-    'http://sinopia.io/users/webid4Admin1',
-    'http://sinopia.io/users/webid4Admin2'
+    'sinopia-devs_client-tester',
+    'ndushay',
   ]
 }

--- a/src/populateEmptyTrellis.js
+++ b/src/populateEmptyTrellis.js
@@ -1,10 +1,24 @@
+// NOTE:  script assumes
+//  1) there is a valid AWS Cognito token available.
+//  You can populate this file via `bin/authenticate`, at which point you will
+//  be prompted for a Sinopia Cognito pool username and password.
+//  2) AWS_PROFILE and AUTH_TEST_PASS will be set -- these allow us to use authenticateClient.webId(username)
+
 import config from 'config'
 import fs from 'fs'
 import Mustache from 'mustache'
 import request from 'sync-request'
 import sleep from 'sleep'
+import AuthenticateClient from './authenticateClient'
 
 const baseUrl = Boolean(process.env.INSIDE_CONTAINER) ? 'http://platform:8080' : config.get('baseUrl')
+
+// FIXME: see github issue #63
+//  eventually, we will have adminusername and adminpassword from ENV vars so we should
+//  obtain our own cognito token.
+//  we will also get appropriate AWS_ACCESS_KEY_ID and  AWS_SECRET_ACCESS_KEY, which should allow us to
+//  use AWS SDK to get webid from username
+
 
 const renderTemplateFile = (templatePath, templateValues) => {
   const template = fs.readFileSync(templatePath, 'utf8')
@@ -56,9 +70,6 @@ if (response.statusCode == 404) {
 }
 
 Object.entries(config.get('groups')).forEach(([slug, label]) => {
-  // Pause between requests to give Trellis time to persist data
-  sleep.sleep(1)
-
   console.log(`creating ${slug} group container`)
 
   response = request('HEAD', `${baseUrl}/repository/${slug}`)
@@ -88,20 +99,36 @@ Object.entries(config.get('groups')).forEach(([slug, label]) => {
   }
 })
 
-// Pause between requests to give Trellis time to persist data
-sleep.sleep(1)
-
 // Do ACLs last, i.e., *after* creating containers, else we require a valid JWT for the above operations
 console.log('setting root container ACLs')
 
-request('PATCH', `${baseUrl}/?ext=acl`, {
-  headers: {
-    'Content-Type': 'application/sparql-update',
-    'Authorization': `Bearer ${token}`
-  },
-  body: renderTemplateFile('./fixtureWAC/rootWAC.sparql.mustache', {
-    adminAgents: config.get('adminUsers').map(webid => {
-      return `    </#control> acl:agent <${webid}> .`
-    }).join("\n")
+// FIXME:  will remove these hardcoded values in github issue #63
+// const username = config.get('testUser')  // no testUser in default.js
+const username = 'sinopia-devs_client-tester'
+const password = process.env.AUTH_TEST_PASS
+
+const client = new AuthenticateClient(username, password)
+
+async function adminUserWebids() {
+  return await Promise.all(config.get('adminUsers').map(adminUserName => client.webId(adminUserName)))
+}
+
+async function doRootAclRequest() {
+  const adminWebids = await adminUserWebids()
+  request('PATCH', `${baseUrl}/?ext=acl`, {
+    headers: {
+      'Content-Type': 'application/sparql-update',
+      'Authorization': `Bearer ${token}`
+    },
+    body: renderTemplateFile(
+      './fixtureWAC/rootWAC.sparql.mustache',
+      {
+        adminAgents: adminWebids.map(webid => {
+          return `    </#control> acl:agent <${webid}> .`
+        }).join("\n")
+      }
+    )
   })
-})
+}
+
+doRootAclRequest()


### PR DESCRIPTION
Closes #56

Besides tweaking populateEmptyTrellis script:
- I changed some test fixtures to be more like how we'll do WAC in production.
- Changing the config file settings used by populateEmptyTrellis affected WebAccessControl validation of WAC

When reviewing, please expand the webAccessControl.test.js file - it has the most changes, but isn't too overwhelming to review.

This is, effectively, an intermediate step - #63 is about getting past hardcoding usernames in the scripts and will also address config information being set in environment vars by terraform for deployments to AWS (dev, stage, prod).

Fun fact:  testing for .toThrow for an async method is ... non-obvious.  And the syntax I found on my first x web searches didn't work for some reason (some config thing?  some babel thing??)