### PR TITLE
use ENV vars when available, otherwise config values

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,74 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/1abbbb1e7eef5ad1a9a5/maintainability)](https://codeclimate.com/github/LD4P/sinopia_acl/maintainability)
 
 # sinopia_acl
-node.js based code to interact with WebACL data on Sinopia server
+node.js based code to interact with WebACL data on Sinopia server.
 
 WebACL (https://www.w3.org/wiki/WebAccessControl) is how we will gate access to various LDP containers on the server.
 
 The "copy of record" of group/webID mappings will be in the Sinopia server.
 
+## Prerequisites
+
+You will need to install the npm packages before running any of the code (which also requires that the npm package manager itself is installed)
+
+```shell
+$ npm install
+```
+
 ## Command Line
 
-This code will have a simple CLI for Sinopia Server admins to use, to be developed in a future work cycle (as of April, 2019).
+This code may have a simple CLI for Sinopia Server admins to use to be developed in a future work cycle (as of April, 2019).
 
-It will expect the admin user to have a valid JWT in a .cognitoToken file (to allow Trellis to know the admin user has permisssions to make the changes to WebACL data). You can populate this file via `bin/authenticate`, at which point you will be prompted for your Sinopia Cognito pool username and password.
+### Spinning up Trellis LDP Server
 
-To spin up Trellis and its dependencies with the Sinopia container structure (root, repository, and group containers) and ACLs (declared on root container) pre-created, you can do using the `platformdata` docker-compose service:
+To spin up Trellis and its dependencies with the Sinopia container structure (root, repository, and group containers) and ACLs (declared on root container) pre-created, use the `platformdata` docker-compose service:
 
 ```shell
 # Add -d flag to run containers in background
 $ docker-compose up platformdata
 ```
+
+To spin up Trellis and its dependencies without the container structure and ACLs pre-created, use the `platform` docker-compose service:
+
+```shell
+# Add -d flag to run containers in background
+$ docker-compose up platform
+```
+
+### Migration Script to Populate existing Trellis LDP Server with Sinopia container structure and ACLs
+
+There is a script to populate a running Trellis LDP server with the Sinopia container structure (root, repository, and group containers) and ACLs (declared on root container).
+
+This script can be run repeatedly
+ - it copes with containers if they already exist
+ - it will overwrite the existing ACL for the root container (requires COGNITO_ADMIN_USER to already be on existing root ACL, tho!)
+
+#### Requirements:
+
+- an AWS Cognito Sinopia user pool account with sufficient permissions to get info about a different user in the pool.
+
+These env vars must be set:
+- COGNITO_ADMIN_USER  (defaults to sinopia-devs_client-tester)
+- COGNITO_ADMIN_PASSWORD
+- one of:
+    - AWS_PROFILE
+   or
+    - AWS_ACCESS_KEY_ID and
+    - AWS_SECRET_ACCESS_KEY
+- TRELLIS_BASE_URL  (defaults to http://localhost:8080)
+
+If the desired AWS Cognito pool is not the Cognito Sinopia development pool, these env vars are also needed:
+- COGNITO_USER_POOL_ID
+- COGNITO_CLIENT_ID
+- AWS_REGION
+- AWS_COGNITO_DOMAIN
+
+#### Example:
+
+```shell
+$ COGNITO_ADMIN_USER=hoohah COGNITO_ADMIN_PASSWORD=foobar AWS_PROFILE=barfoo bin/migrate
+```
+
 
 ## Testing
 
@@ -38,11 +88,11 @@ $ npm run eslint
 To run unit tests:
 
 ```shell
-$ AUTH_TEST_PASS=foobar AWS_PROFILE=barfoo npm test
+$ COGNITO_ADMIN_PASSWORD=foobar AWS_PROFILE=barfoo npm test
 ```
 
 Note that you will need to replace the value of
--  `AUTH_TEST_PASS` with the actual password of the Cognito testing account we have created. For that, see the Sinopia dev `shared_configs` [repository](https://github.com/sul-dlss/shared_configs/tree/sinopia-dev) or ask a fellow Sinopia developer.
+-  `COGNITO_ADMIN_PASSWORD` with the actual password of the Cognito testing account we have created. For that, see the Sinopia dev `shared_configs` [repository](https://github.com/sul-dlss/shared_configs/tree/sinopia-dev) or ask a fellow Sinopia developer.
 - `AWS_PROFILE` with the value of your developer profile, e.g. 'dev' or 'my-id@sul-dlss-dev'
 
 ### Integration

--- a/__tests__/authenticateClient.test.js
+++ b/__tests__/authenticateClient.test.js
@@ -4,7 +4,7 @@ import fs from 'fs'
 
 describe('AuthenticateClient', () => {
   const username = config.get('testUser')
-  const password = process.env.AUTH_TEST_PASS
+  const password = config.get('cognitoAdminPassword')
 
   describe('constructor()', () => {
     describe('username and password validation', () => {
@@ -157,7 +157,7 @@ describe('AuthenticateClient', () => {
     describe('accessTokenPromise()', () => {
       const client = new AuthenticateClient(username, password)
 
-      test('gets accessToken ', () => {
+      test('gets accessToken', async () => {
         return client.accessTokenPromise()
           .then((jwt) => {
             expect(jwt).toBeTruthy()
@@ -178,11 +178,11 @@ describe('AuthenticateClient', () => {
 
   describe('webId()', () => {
     const client = new AuthenticateClient(username, password)
-    const desiredUser = config.get('testUser')
+    const desiredUser = username
 
     test('returns valid webId', async () => {
       const webid = await client.webId(desiredUser)
-      const startsWithRegex = new RegExp(`^${config.get('webidBaseUrl')}/${config.get('userPoolId')}/`)
+      const startsWithRegex = new RegExp(`^https://${client.cognitoDomain}/${client.userPoolId}/`)
       expect(webid).toMatch(startsWithRegex)
       const endsWithUuidRegex = new RegExp("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
       expect(webid).toMatch(endsWithUuidRegex)

--- a/__tests__/populateEmptyTrellis.integration.js
+++ b/__tests__/populateEmptyTrellis.integration.js
@@ -6,16 +6,11 @@ const rootAclUrl = Boolean(process.env.INSIDE_CONTAINER) ? 'http://platform:8080
 // assumes docker-compose build is running
 describe('populateEmptyTrellis integration', () => {
   test('root container WAC validates', async () => {
-    console.log('IN TeST!!!!!!!')
     const rootWAC = await request('GET', rootAclUrl)
-    console.dir(rootWAC.getBody('utf8'))
-
-    // const rootNode = namedNode('http://platform:8080/#auth')
     const webAC = new WebAccessControl('', rootWAC.getBody('utf8'))
     expect(webAC.validates()).toBeTruthy()
   })
 
   test.skip('throws exception if unable to get webid for username', () => {
-
   })
 })

--- a/__tests__/populateEmptyTrellis.integration.js
+++ b/__tests__/populateEmptyTrellis.integration.js
@@ -1,0 +1,21 @@
+import request from 'sync-request'
+import { WebAccessControl } from '../src/webAccessControl'
+
+const rootAclUrl = Boolean(process.env.INSIDE_CONTAINER) ? 'http://platform:8080/?ext=acl' : 'http://localhost:8080/?ext=acl'
+
+// assumes docker-compose build is running
+describe('populateEmptyTrellis integration', () => {
+  test('root container WAC validates', async () => {
+    console.log('IN TeST!!!!!!!')
+    const rootWAC = await request('GET', rootAclUrl)
+    console.dir(rootWAC.getBody('utf8'))
+
+    // const rootNode = namedNode('http://platform:8080/#auth')
+    const webAC = new WebAccessControl('', rootWAC.getBody('utf8'))
+    expect(webAC.validates()).toBeTruthy()
+  })
+
+  test.skip('throws exception if unable to get webid for username', () => {
+
+  })
+})

--- a/config/default.js
+++ b/config/default.js
@@ -2,7 +2,8 @@
 const defer = require('config/defer').deferConfig
 
 module.exports = {
-  baseUrl: 'http://localhost:8080',
+  baseUrl: process.env.TRELLIS_BASE_URL || 'http://localhost:8080',
+  awsRegion: process.env.AWS_REGION || 'us-west-2',
   // usernames from the development Sinopia Cognito user pool (same names used in stage and prod Cogntio pools)
   adminUsers: [
     'jgreben',
@@ -12,11 +13,14 @@ module.exports = {
     'ndushay',
     'suntzu'
   ],
-  userPoolId: 'us-west-2_CGd9Wq136', // development
-  userPoolAppClientId: '2u6s7pqkc1grq1qs464fsi82at', // development
+  // admin username for getting webids given usernames;  explicit values here are from development Sinopia Cognito user pool
+  cognitoAdminUser: process.env.COGNITO_ADMIN_USER || 'sinopia-devs_client-tester',
+  cognitoAdminPassword: process.env.COGNITO_ADMIN_PASSWORD,  // this should NOT have a default value
+  awsProfile: process.env.AWS_PROFILE || '',
+  userPoolId: process.env.COGNITO_USER_POOL_ID || 'us-west-2_CGd9Wq136',
+  userPoolAppClientId: process.env.COGNITO_CLIENT_ID || '2u6s7pqkc1grq1qs464fsi82at',
   cognitoTokenFile: '.cognitoToken',
-  awsRegion: 'us-west-2',
-  webidBaseUrl: defer(function () { return `https://cognito-idp.${this.awsRegion}.amazonaws.com` }), // no trailing slash
+  cognitoDomain: process.env.AWS_COGNITO_DOMAIN || defer(function () { return `cognito-idp.${this.awsRegion}.amazonaws.com` }), // no trailing slash
   groups: {
     alberta: 'University of Alberta',
     boulder: 'University of Colorado, Boulder',

--- a/config/test.js
+++ b/config/test.js
@@ -1,5 +1,5 @@
 module.exports = {
-  testUser: 'sinopia-devs_client-tester',
+  testUser: process.env.COGNITO_ADMIN_USER || 'sinopia-devs_client-tester',
   // override the default value for testing
   adminUsers: [
     'sinopia-devs_client-tester',

--- a/src/sinopiaClient.js
+++ b/src/sinopiaClient.js
@@ -3,7 +3,8 @@ import SimpleRequest from './simpleRequest'
 
 export default class SinopiaClient {
   constructor() {
-    this.groupContainerUrl = `${config.get('baseUrl')}/repository`
+    this.trellisBaseUrl = config.get('baseUrl')
+    this.groupContainerUrl = `${this.trellisBaseUrl}/repository`
     this.requester = new SimpleRequest(this.groupContainerUrl)
   }
 

--- a/src/webAccessControl.js
+++ b/src/webAccessControl.js
@@ -87,13 +87,8 @@ export class WebAccessControl {
   }
 
   async adminUserWebIds() {
-    // FIXME:  will remove these hardcoded values in github issue #63
-    // const username = config.get('testUser')  // no testUser in default.js
-    const username = 'sinopia-devs_client-tester'
-    const password = process.env.AUTH_TEST_PASS
-
-    const client = new AuthenticateClient(username, password)
-    return await Promise.all(config.get('adminUsers').map(adminUserName => client.webId(adminUserName)))
+    const client = new AuthenticateClient(config.get('cognitoAdminUser'), config.get('cognitoAdminPassword'))
+    return await Promise.all(config.get('adminUsers').map(adminName => client.webId(adminName)))
   }
 
   // expect parseWac to have been called on desired WAC


### PR DESCRIPTION
Using ENV vars when available will allow the `populateEmptyTrellis` script (a.k.a. `bin/migrate`) to be run against all the AWS deployed containers.  

This approach accommodates the different trellis instances (local, dev, stage, prod) and the different AWS Cognito pools (development, staging, production).  It is necessary prep work for #58, #59, and #60.

This PR accomplishes much of #63 but doesn't quite close it as these still remain:

```
- npm package will need to be updated

- possibly be more intentional about how sinopia_editor, sinopia_server, sinopia_indexing_pipeline get the correct code.
```