### PR TITLE
Allow platformdata docker-compose service to pass AWS credentials through

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,8 @@
-npm-debug.log
-Dockerfile
-.dockerignore
-.node-version
 .cognitoToken
+.dockerignore
+.env
+.git
+.node-version
+Dockerfile
+coverage
+npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-node_modules
-coverage
 .cognitoToken
+.env
+coverage
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,4 @@ RUN /bin/bash -c 'chown -R circleci node_modules'
 
 USER circleci
 
-# Add babel-node to PATH
-ENV PATH "$PATH:node_modules/.bin"
-
 RUN npm install

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ To spin up Trellis and its dependencies with the Sinopia container structure (ro
 $ docker-compose up platformdata
 ```
 
+**NOTE**: In order for the above to work, you will need to set `COGNITO_ADMIN_PASSWORD`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY` in a file named `.env` in the sinopia_acl root.
+
 To spin up Trellis and its dependencies without the container structure and ACLs pre-created, use the `platform` docker-compose service:
 
 ```shell
@@ -130,13 +132,11 @@ $ docker-compose down
 
 - In an ideal world, we would validate any WebACL to be written to the server.  However, here does not seem to be an existing WebACL validation package -- JSON schema, npm module, RDF shapes, whatever.
 
-- We will separate out the CLI from the WebACL manipulation and the interaction with the Sinopia server.
-    There are npm packages for CLI that we can leverage, such as cli, minimist, ...
+- We separate out the CLI from the WebACL manipulation and the interaction with the Sinopia server.
 
 - We will see if we can use npm jsonacl https://www.npmjs.com/package/jsonacl for node ACL manipulation, or something similar
 
-- We will (eventually) create an npm package that could then be imported in the future by a GUI
-    team members will need to be added to npm registry when we create npm package
+- We publish an npm package that can be imported by a GUI
 
 ## Build and push image
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,9 @@ services:
     environment:
       INSIDE_CONTAINER: 'true'
       TRELLIS_BASE_URL: http://platform:8080
-      COGNITO_USER_POOL_ID: ${COGNITO_USER_POOL_ID:-us-west-2_CGd9Wq136}
-      AWS_COGNITO_REGION: ${AWS_COGNITO_REGION:-us-west-2}
+      COGNITO_ADMIN_PASSWORD: "${COGNITO_ADMIN_PASSWORD}" # add to .env file (DO NOT CHECK IN)
+      AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID}" # add to .env file (DO NOT CHECK IN)
+      AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}" # add to .env file (DO NOT CHECK IN)
     command: dockerize -wait tcp://platform:8080 -timeout 3m bin/migrate
     depends_on:
       - platform

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     environment:
       INSIDE_CONTAINER: 'true'
       TRELLIS_BASE_URL: http://platform:8080
+      COGNITO_USER_POOL_ID: ${COGNITO_USER_POOL_ID:-us-west-2_CGd9Wq136}
+      AWS_REGION: ${AWS_REGION:-us-west-2}
       COGNITO_ADMIN_PASSWORD: "${COGNITO_ADMIN_PASSWORD}" # add to .env file (DO NOT CHECK IN)
       AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID}" # add to .env file (DO NOT CHECK IN)
       AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}" # add to .env file (DO NOT CHECK IN)
@@ -27,7 +29,7 @@ services:
       TRELLIS_LOGGING_LEVEL: INFO
       TRELLIS_CONSOLE_LOGGING_THRESHOLD: INFO
       COGNITO_USER_POOL_ID: ${COGNITO_USER_POOL_ID:-us-west-2_CGd9Wq136}
-      AWS_COGNITO_REGION: ${AWS_COGNITO_REGION:-us-west-2}
+      AWS_REGION: ${AWS_REGION:-us-west-2}
     ports:
       - 8080:8080
       - 8081:8081


### PR DESCRIPTION
Also includes:
* Make style of function definitions consistent in `populateEmptyTrellis.js`
* Update and clarify the README
* Add ignores to git and docker

connects to #67
extracted from #68